### PR TITLE
[refactor]이슈 대시보드 최종 수정

### DIFF
--- a/src/components/common/DashboardTabs.tsx
+++ b/src/components/common/DashboardTabs.tsx
@@ -28,9 +28,9 @@ export type DashboardTabsContentProps = {
   children: React.ReactNode;
 };
 
-/**
- * @description 대시보드용 탭 컨테이너
- */
+/* ------------------------------------------------------------
+   DashboardTabs (Container)
+------------------------------------------------------------ */
 export const DashboardTabs = ({
                                 defaultValue,
                                 onValueChange,
@@ -44,31 +44,30 @@ export const DashboardTabs = ({
   };
 
   const enhancedChildren = React.Children.map(children, (child) => {
-    if (!React.isValidElement(child)) {
-      return child;
-    }
+    if (!React.isValidElement(child)) return child;
 
-    // 탭 버튼 리스트에만 상태 주입
-    if (child.type === DashboardTabsList) {
+    // ⭐ displayName 비교로 안정적으로 매칭
+    if ((child.type as any).displayName === 'DashboardTabsList') {
       return React.cloneElement(
         child as React.ReactElement<DashboardTabsListProps>,
         {
           activeTab,
           onTabChange: handleTabChange,
-        },
+        }
       );
     }
 
-    // 나머지 자식들은 그대로 렌더
     return child;
   });
 
-  return <div className='flex flex-col gap-4'>{enhancedChildren}</div>;
+  return <div className="flex flex-col gap-4">{enhancedChildren}</div>;
 };
 
-/**
- * @description 탭 버튼 묶음
- */
+DashboardTabs.displayName = 'DashboardTabs';
+
+/* ------------------------------------------------------------
+   Tabs List (Button Group)
+------------------------------------------------------------ */
 export const DashboardTabsList = ({
                                     className = '',
                                     activeTab,
@@ -85,16 +84,18 @@ export const DashboardTabsList = ({
           {
             activeTab,
             onTabClick: handleChange,
-          },
-        ),
+          }
+        )
       )}
     </div>
   );
 };
 
-/**
- * @description 개별 탭 버튼
- */
+DashboardTabsList.displayName = 'DashboardTabsList';
+
+/* ------------------------------------------------------------
+   Tabs Trigger (Each Button)
+------------------------------------------------------------ */
 export const DashboardTabsTrigger = ({
                                        className = '',
                                        value,
@@ -106,12 +107,12 @@ export const DashboardTabsTrigger = ({
 
   const baseClasses =
     'inline-flex items-center gap-2 rounded-full border px-4 py-2 ' +
-    'text-sm font-medium transition-colors disabled:pointer-events-none ' +
-    'disabled:opacity-50';
+    'text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50';
 
+  // ⭐ 클릭 시 회색 배경 적용된 버전
   const stateClasses = isActive
-    ? 'border-border-strong bg-surface-elevated text-primary shadow-xs'
-    : 'border-border-subtle bg-surface text-secondary hover:border-border-strong';
+    ? 'border-gray-300 bg-gray-100 text-gray-900 shadow-sm'
+    : 'border-gray-200 bg-white text-gray-500 hover:bg-gray-50';
 
   const handleClick = (): void => {
     onTabClick?.(value);
@@ -119,7 +120,7 @@ export const DashboardTabsTrigger = ({
 
   return (
     <button
-      type='button'
+      type="button"
       onClick={handleClick}
       className={`${baseClasses} ${stateClasses} ${className}`}
     >
@@ -128,10 +129,11 @@ export const DashboardTabsTrigger = ({
   );
 };
 
-/**
- * @description 탭 콘텐츠 컨테이너
- * - value === activeTab 일 때만 children 렌더
- */
+DashboardTabsTrigger.displayName = 'DashboardTabsTrigger';
+
+/* ------------------------------------------------------------
+   Tabs Content (Tab Panel)
+------------------------------------------------------------ */
 export const DashboardTabsContent = ({
                                        className = '',
                                        value,
@@ -141,3 +143,5 @@ export const DashboardTabsContent = ({
   activeTab === value ? (
     <div className={`space-y-4 ${className}`}>{children}</div>
   ) : null;
+
+DashboardTabsContent.displayName = 'DashboardTabsContent';

--- a/src/components/dashboard/NewsCard.tsx
+++ b/src/components/dashboard/NewsCard.tsx
@@ -25,11 +25,11 @@ export const NewsCard = ({ news }: NewsCardProps) => (
 
           <div className='flex flex-wrap items-center gap-x-4 gap-y-2 text-xs sm:text-sm text-secondary'>
             <div className='flex items-center gap-1'>
-              <Newspaper className='w-4 h-4 text-brand-primary' />
+              <Newspaper className="w-4 h-4 text-gray-600" />
               <span>{news.source}</span>
             </div>
             <div className='flex items-center gap-1'>
-              <Calendar className='w-4 h-4 text-brand-primary' />
+              <Calendar className="w-4 h-4 text-gray-600" />
               <span>{news.publishedAt}</span>
             </div>
           </div>

--- a/src/components/dashboard/NewsCard.tsx
+++ b/src/components/dashboard/NewsCard.tsx
@@ -11,7 +11,7 @@ export const NewsCard = ({ news }: NewsCardProps) => (
     rel='noopener noreferrer'
     className='block'
   >
-    <Card className='p-4 sm:p-6 hover:shadow-lg transition-shadow duration-300 cursor-pointer border-border-subtle'>
+    <Card className='bg-white p-4 sm:p-6 hover:shadow-lg transition-shadow duration-300 cursor-pointer border-border-subtle'>
       <div className='flex items-start justify-between gap-4'>
         <div className='flex-1 min-w-0'>
           <div className='flex items-center gap-2 mb-3'>

--- a/src/components/dashboard/NewsCard.tsx
+++ b/src/components/dashboard/NewsCard.tsx
@@ -16,7 +16,7 @@ export const NewsCard = ({ news }: NewsCardProps) => (
         <div className='flex-1 min-w-0'>
           <div className='flex items-center gap-2 mb-3'>
             <Badge variant='outline'>{news.country}</Badge>
-            <Badge variant='secondary'>{news.category}</Badge>
+            <Badge variant='secondary'className="bg-gray-100 text-gray-700 border border-gray-300">{news.category}</Badge>
           </div>
 
           <h3 className='text-base sm:text-lg font-semibold mb-2 text-primary hover:text-brand-primary transition-colors line-clamp-2'>

--- a/src/components/dashboard/NewsCard.tsx
+++ b/src/components/dashboard/NewsCard.tsx
@@ -25,11 +25,11 @@ export const NewsCard = ({ news }: NewsCardProps) => (
 
           <div className='flex flex-wrap items-center gap-x-4 gap-y-2 text-xs sm:text-sm text-secondary'>
             <div className='flex items-center gap-1'>
-              <Newspaper className="w-4 h-4 text-gray-600" />
+              <Newspaper className="w-4 h-4 text-text-secondary" />
               <span>{news.source}</span>
             </div>
             <div className='flex items-center gap-1'>
-              <Calendar className="w-4 h-4 text-gray-600" />
+              <Calendar className="w-4 h-4 text-text-secondary" />
               <span>{news.publishedAt}</span>
             </div>
           </div>

--- a/src/pages/ui/MainDashboardPage.tsx
+++ b/src/pages/ui/MainDashboardPage.tsx
@@ -28,7 +28,7 @@ export const MainDashboardPage = () => {
   );
 
   return (
-    <div className="min-h-screen bg-surface font-sans">
+    <div className="min-h-screen font-sans">
       {/* 공통 레이아웃 헤더 */}
       <Header />
 
@@ -36,6 +36,7 @@ export const MainDashboardPage = () => {
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* 페이지 타이틀 영역 */}
         <header className="mb-8">
+
           <h1 className="text-2xl sm:text-3xl font-extrabold text-primary mb-1">
             <Globe className="inline-block w-6 h-6 mr-3 text-brand-primary" />
             해외 이슈 대시보드
@@ -46,6 +47,7 @@ export const MainDashboardPage = () => {
         </header>
 
         {/* 탭 + 리스트 영역 */}
+
         <DashboardTabs defaultValue="all" onValueChange={onChangeTab}>
           {/* 전체 / 관심 국가 탭 */}
           <DashboardTabsList className="mb-6 flex flex-wrap">
@@ -77,7 +79,7 @@ export const MainDashboardPage = () => {
           />
         </DashboardTabs>
       </main>
-    </div>
+      </div>
   );
 };
 

--- a/src/pages/ui/MainDashboardPage.tsx
+++ b/src/pages/ui/MainDashboardPage.tsx
@@ -33,7 +33,7 @@ export const MainDashboardPage = () => {
       <Header />
 
       {/* 페이지 본문 */}
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main className="mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* 페이지 타이틀 영역 */}
         <header className="mb-8">
 
@@ -46,8 +46,9 @@ export const MainDashboardPage = () => {
           </p>
         </header>
 
-        {/* 탭 + 리스트 영역 */}
 
+        <div className="bg-[#F2F4F6] -mx-4 sm:-mx-6 lg:-mx-8 px-4 sm:px-6 lg:px-8 py-8">
+        {/* 탭 + 리스트 영역 */}
         <DashboardTabs defaultValue="all" onValueChange={onChangeTab}>
           {/* 전체 / 관심 국가 탭 */}
           <DashboardTabsList className="mb-6 flex flex-wrap">
@@ -78,6 +79,7 @@ export const MainDashboardPage = () => {
             emptyMessage="설정한 관심 국가에 해당하는 최신 이슈가 없습니다."
           />
         </DashboardTabs>
+        </div>
       </main>
       </div>
   );

--- a/src/pages/ui/MainDashboardPage.tsx
+++ b/src/pages/ui/MainDashboardPage.tsx
@@ -62,7 +62,7 @@ export const MainDashboardPage = () => {
             </DashboardTabsTrigger>
 
             <DashboardTabsTrigger value="interests">
-              <User className="w-4 h-4 mr-2 text-brand-primary" />
+              <User className="w-4 h-4 mr-2 text-[#6B7280]" />
               관심 국가 이슈 ({interestNews.length})
             </DashboardTabsTrigger>
           </DashboardTabsList>

--- a/src/pages/ui/MainDashboardPage.tsx
+++ b/src/pages/ui/MainDashboardPage.tsx
@@ -33,21 +33,25 @@ export const MainDashboardPage = () => {
       <Header />
 
       {/* 페이지 본문 */}
-      <main className="mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main className="pb-8">
         {/* 페이지 타이틀 영역 */}
-        <header className="mb-8">
-
-          <h1 className="text-2xl sm:text-3xl font-extrabold text-primary mb-1">
-            <Globe className="inline-block w-6 h-6 mr-3 text-brand-primary" />
+        <header className="mt-6 sm:mt-8 mb-8 pl-4 sm:pl-6 lg:pl-8">
+          <div className="flex items-center gap-3 mb-1">
+            <Globe className="w-7 h-7 text-brand-primary" />
+            <h1 className="text-2xl sm:text-3xl font-extrabold text-primary">
             해외 이슈 대시보드
           </h1>
+          </div>
           <p className="text-sm sm:text-base text-secondary">
             해외 주요 법률 및 정책 개정 소식을 확인하세요.
           </p>
         </header>
 
 
-        <div className="bg-[#F2F4F6] -mx-4 sm:-mx-6 lg:-mx-8 px-4 sm:px-6 lg:px-8 py-8">
+          {/* 회색 배경 전체 영역 */}
+          <div className="bg-[#F2F4F6]">
+            {/* 중앙 컨텐츠 영역 max-width 적용 */}
+            <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-8">
         {/* 탭 + 리스트 영역 */}
         <DashboardTabs defaultValue="all" onValueChange={onChangeTab}>
           {/* 전체 / 관심 국가 탭 */}
@@ -80,6 +84,7 @@ export const MainDashboardPage = () => {
           />
         </DashboardTabs>
         </div>
+          </div>
       </main>
       </div>
   );

--- a/src/pages/ui/MainDashboardPage.tsx
+++ b/src/pages/ui/MainDashboardPage.tsx
@@ -42,7 +42,7 @@ export const MainDashboardPage = () => {
             해외 이슈 대시보드
           </h1>
           </div>
-          <p className="text-sm sm:text-base text-secondary">
+          <p className="text-sm sm:text-base text-text-secondary">
             해외 주요 법률 및 정책 개정 소식을 확인하세요.
           </p>
         </header>


### PR DESCRIPTION

<img width="2821" height="1486" alt="image" src="https://github.com/user-attachments/assets/bce1e138-0434-481a-a20a-8e3897a36f5c" />

1. 배경 회색으로 수정
2. 뉴스카드 색상 흰색으로 지정 및 길이 1120으로 수정
3. 대시보드 타이틀 상하 좌우 위치 수정
4. 각 세부 아이콘 색상 회색으로 통일

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

**스타일**
- 뉴스 카드의 배경색 및 배지 스타일 개선
- 대시보드 페이지 레이아웃, 여백 및 내부 컨테이너 정리
- 아이콘 색상 업데이트(중립 그레이로 변경)

**리팩토**
- 공개 컴포넌트에 displayName 메타데이터 추가(안정적 식별 목적)
- 자식 컴포넌트 매칭 로직을 displayName 기준으로 조정
- 인라인 스타일·포맷 소소 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->