### PR TITLE
[feat] 관심 국가 설정 모달 제작

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,25 +1,7 @@
-import { Routes, Route, Navigate } from 'react-router-dom';
-import { MainDashboardPage } from '@/pages/ui/MainDashboardPage';
-import { LawCollectionPage } from '@/pages/ui/LawCollectionPage';
-import { Header } from '@/components/layout/Header';
-
-const HeaderOnlyPage = () => (
-  <div className="min-h-screen bg-surface font-sans">
-    <Header />
-  </div>
-);
+import { AppRoutes } from '@/routes/routes';
 
 export function App() {
-  return (
-    <Routes>
-      <Route path="/" element={<MainDashboardPage />} />
-      <Route path="/law-collection" element={<LawCollectionPage />} />
-      <Route path="/ai-consulting" element={<HeaderOnlyPage />} />
-      <Route path="/law-compare" element={<HeaderOnlyPage />} />
-      <Route path="/mypage" element={<HeaderOnlyPage />} />
-      <Route path="*" element={<Navigate to="/" replace />} />
-    </Routes>
-  );
+  return <AppRoutes />;
 }
 
 export default App;

--- a/src/components/common/DashboardTabs.tsx
+++ b/src/components/common/DashboardTabs.tsx
@@ -1,55 +1,65 @@
-import React, { useState } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useId,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
+import type {
+  DashboardTabsContentProps,
+  DashboardTabsListProps,
+  DashboardTabsProps,
+  DashboardTabsTriggerProps,
+} from '@/types/tabs';
 
-export type DashboardTabsProps = {
-  defaultValue: string;
-  value?: string;
-  onValueChange: (value: string) => void;
-  children: React.ReactNode;
-};
-
-export type DashboardTabsListProps = {
-  className?: string;
-  activeTab?: string;
-  onTabChange?: (value: string) => void;
-  children: React.ReactNode;
-};
-
-export type DashboardTabsTriggerProps = {
-  className?: string;
-  value: string;
-  activeTab?: string;
-  onTabClick?: (value: string) => void;
-  children: React.ReactNode;
-};
-
-export type DashboardTabsContentProps = {
-  className?: string;
-  value: string;
+type DashboardTabsContextValue = {
   activeTab: string;
-  children: React.ReactNode;
+  onTabChange: (value: string) => void;
+  getTabId: (value: string) => string;
+  getPanelId: (value: string) => string;
 };
+
+const DashboardTabsContext =
+  createContext<DashboardTabsContextValue | null>(null);
+
+const useDashboardTabsContext = () => useContext(DashboardTabsContext);
 
 /* ------------------------------------------------------------
    DashboardTabs (Container)
 ------------------------------------------------------------ */
 export const DashboardTabs = ({
-                                defaultValue,
-                                value,
-                                onValueChange,
-                                children,
-                              }: DashboardTabsProps) => {
+  defaultValue,
+  value,
+  onValueChange,
+  children,
+}: DashboardTabsProps) => {
   const isControlled = value !== undefined;
   const [uncontrolledValue, setUncontrolledValue] =
     useState<string>(defaultValue);
 
   const activeTab = isControlled ? value ?? defaultValue : uncontrolledValue;
+  const tabsId = useId();
 
-  const handleTabChange = (value: string): void => {
-    if (!isControlled) {
-      setUncontrolledValue(value);
-    }
-    onValueChange(value);
-  };
+  const handleTabChange = useCallback(
+    (nextValue: string): void => {
+      if (!isControlled) {
+        setUncontrolledValue(nextValue);
+      }
+      onValueChange(nextValue);
+    },
+    [isControlled, onValueChange],
+  );
+
+  const contextValue = useMemo(
+    () => ({
+      activeTab,
+      onTabChange: handleTabChange,
+      getTabId: (val: string) => `${tabsId}-tab-${val}`,
+      getPanelId: (val: string) => `${tabsId}-panel-${val}`,
+    }),
+    [activeTab, handleTabChange, tabsId],
+  );
 
   const enhancedChildren = React.Children.map(children, (child) => {
     if (!React.isValidElement(child)) return child;
@@ -65,14 +75,19 @@ export const DashboardTabs = ({
         {
           activeTab,
           onTabChange: handleTabChange,
-        }
+          tabsId,
+        },
       );
     }
 
     return child;
   });
 
-  return <div className="flex flex-col gap-4">{enhancedChildren}</div>;
+  return (
+    <DashboardTabsContext.Provider value={contextValue}>
+      <div className="flex flex-col gap-4">{enhancedChildren}</div>
+    </DashboardTabsContext.Provider>
+  );
 };
 
 DashboardTabs.displayName = 'DashboardTabs';
@@ -81,12 +96,15 @@ DashboardTabs.displayName = 'DashboardTabs';
    Tabs List (Button Group)
 ------------------------------------------------------------ */
 export const DashboardTabsList = ({
-                                    className = '',
-                                    activeTab,
-                                    onTabChange,
-                                    children,
-                                  }: DashboardTabsListProps) => {
-  const handleChange = onTabChange ?? (() => {});
+  className = '',
+  activeTab,
+  onTabChange,
+  tabsId,
+  children,
+}: DashboardTabsListProps) => {
+  const ctx = useDashboardTabsContext();
+  const currentActiveTab = ctx?.activeTab ?? activeTab;
+  const handleChange = ctx?.onTabChange ?? onTabChange ?? (() => {});
 
   return (
     <div
@@ -94,15 +112,29 @@ export const DashboardTabsList = ({
       role="tablist"
       aria-label="대시보드 탭"
     >
-      {React.Children.map(children, (child) =>
-        React.cloneElement(
+      {React.Children.map(children, (child) => {
+        if (!React.isValidElement(child)) return child;
+
+        const childProps = child.props as DashboardTabsTriggerProps;
+        const valueProp = childProps.value;
+
+        const fallbackTabId = tabsId
+          ? `${tabsId}-tab-${valueProp}`
+          : undefined;
+        const fallbackPanelId = tabsId
+          ? `${tabsId}-panel-${valueProp}`
+          : undefined;
+
+        return React.cloneElement(
           child as React.ReactElement<DashboardTabsTriggerProps>,
           {
-            activeTab,
+            activeTab: currentActiveTab,
             onTabClick: handleChange,
-          }
-        )
-      )}
+            tabId: ctx ? ctx.getTabId(valueProp) : fallbackTabId,
+            panelId: ctx ? ctx.getPanelId(valueProp) : fallbackPanelId,
+          },
+        );
+      })}
     </div>
   );
 };
@@ -113,24 +145,31 @@ DashboardTabsList.displayName = 'DashboardTabsList';
    Tabs Trigger (Each Button)
 ------------------------------------------------------------ */
 export const DashboardTabsTrigger = ({
-                                       className = '',
-                                       value,
-                                       activeTab,
-                                       onTabClick,
-                                       children,
-                                     }: DashboardTabsTriggerProps) => {
-  const isActive = activeTab === value;
+  className = '',
+  value,
+  activeTab,
+  onTabClick,
+  tabId,
+  panelId,
+  children,
+}: DashboardTabsTriggerProps) => {
+  const ctx = useDashboardTabsContext();
+  const currentActiveTab = ctx?.activeTab ?? activeTab;
+  const isActive = currentActiveTab === value;
+
+  const resolvedTabId = ctx ? ctx.getTabId(value) : tabId;
+  const resolvedPanelId = ctx ? ctx.getPanelId(value) : panelId;
 
   const baseClasses =
     'inline-flex items-center gap-2 rounded-full border px-4 py-2 ' +
     'text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50';
 
-  // ⭐ 클릭 시 회색 배경 적용된 버전
   const stateClasses = isActive
     ? 'border-gray-300 bg-gray-100 text-gray-900 shadow-sm'
     : 'border-gray-200 bg-white text-gray-500 hover:bg-gray-50';
 
   const handleClick = (): void => {
+    ctx?.onTabChange?.(value);
     onTabClick?.(value);
   };
 
@@ -141,7 +180,8 @@ export const DashboardTabsTrigger = ({
       className={`${baseClasses} ${stateClasses} ${className}`}
       role="tab"
       aria-selected={isActive}
-      aria-pressed={isActive}
+      id={resolvedTabId}
+      aria-controls={resolvedPanelId}
     >
       {children}
     </button>
@@ -154,13 +194,30 @@ DashboardTabsTrigger.displayName = 'DashboardTabsTrigger';
    Tabs Content (Tab Panel)
 ------------------------------------------------------------ */
 export const DashboardTabsContent = ({
-                                       className = '',
-                                       value,
-                                       activeTab,
-                                       children,
-                                     }: DashboardTabsContentProps) =>
-  activeTab === value ? (
-    <div className={`space-y-4 ${className}`}>{children}</div>
-  ) : null;
+  className = '',
+  value,
+  activeTab,
+  tabId,
+  panelId,
+  children,
+}: DashboardTabsContentProps) => {
+  const ctx = useDashboardTabsContext();
+  const currentActiveTab = ctx?.activeTab ?? activeTab;
+  if (currentActiveTab !== value) return null;
+
+  const resolvedPanelId = ctx ? ctx.getPanelId(value) : panelId;
+  const resolvedLabelId = ctx ? ctx.getTabId(value) : tabId;
+
+  return (
+    <div
+      className={`space-y-4 ${className}`}
+      role="tabpanel"
+      id={resolvedPanelId}
+      aria-labelledby={resolvedLabelId}
+    >
+      {children}
+    </div>
+  );
+};
 
 DashboardTabsContent.displayName = 'DashboardTabsContent';

--- a/src/components/common/DashboardTabs.tsx
+++ b/src/components/common/DashboardTabs.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 
 export type DashboardTabsProps = {
   defaultValue: string;
+  value?: string;
   onValueChange: (value: string) => void;
   children: React.ReactNode;
 };
@@ -33,21 +34,32 @@ export type DashboardTabsContentProps = {
 ------------------------------------------------------------ */
 export const DashboardTabs = ({
                                 defaultValue,
+                                value,
                                 onValueChange,
                                 children,
                               }: DashboardTabsProps) => {
-  const [activeTab, setActiveTab] = useState<string>(defaultValue);
+  const isControlled = value !== undefined;
+  const [uncontrolledValue, setUncontrolledValue] =
+    useState<string>(defaultValue);
+
+  const activeTab = isControlled ? value ?? defaultValue : uncontrolledValue;
 
   const handleTabChange = (value: string): void => {
-    setActiveTab(value);
+    if (!isControlled) {
+      setUncontrolledValue(value);
+    }
     onValueChange(value);
   };
 
   const enhancedChildren = React.Children.map(children, (child) => {
     if (!React.isValidElement(child)) return child;
 
-    // ⭐ displayName 비교로 안정적으로 매칭
-    if ((child.type as any).displayName === 'DashboardTabsList') {
+    const childType = child.type as { displayName?: string };
+    const isTabsList =
+      child.type === DashboardTabsList ||
+      childType?.displayName === 'DashboardTabsList';
+
+    if (isTabsList) {
       return React.cloneElement(
         child as React.ReactElement<DashboardTabsListProps>,
         {
@@ -77,7 +89,11 @@ export const DashboardTabsList = ({
   const handleChange = onTabChange ?? (() => {});
 
   return (
-    <div className={`flex items-center gap-2 ${className}`}>
+    <div
+      className={`flex items-center gap-2 ${className}`}
+      role="tablist"
+      aria-label="대시보드 탭"
+    >
       {React.Children.map(children, (child) =>
         React.cloneElement(
           child as React.ReactElement<DashboardTabsTriggerProps>,
@@ -123,6 +139,9 @@ export const DashboardTabsTrigger = ({
       type="button"
       onClick={handleClick}
       className={`${baseClasses} ${stateClasses} ${className}`}
+      role="tab"
+      aria-selected={isActive}
+      aria-pressed={isActive}
     >
       {children}
     </button>

--- a/src/components/dashboard/NewsCard.tsx
+++ b/src/components/dashboard/NewsCard.tsx
@@ -7,35 +7,37 @@ export const NewsCard = ({ news }: NewsCardProps) => (
   <a
     key={news.id}
     href={news.sourceUrl}
-    target='_blank'
-    rel='noopener noreferrer'
-    className='block'
+    target="_blank"
+    rel="noopener noreferrer"
+    className="block"
   >
-    <Card className='bg-white p-4 sm:p-6 hover:shadow-lg transition-shadow duration-300 cursor-pointer border-border-subtle'>
-      <div className='flex items-start justify-between gap-4'>
-        <div className='flex-1 min-w-0'>
-          <div className='flex items-center gap-2 mb-3'>
-            <Badge variant='outline'>{news.country}</Badge>
-            <Badge variant='secondary'className="bg-gray-100 text-gray-700 border border-gray-300">{news.category}</Badge>
+    <Card className="bg-white p-4 sm:p-6 hover:shadow-lg transition-shadow duration-300 cursor-pointer border-border-subtle">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-3">
+            <Badge variant="outline">{news.country}</Badge>
+            <Badge variant="secondary" className="bg-gray-100 text-gray-700 ">
+              {news.category}
+            </Badge>
           </div>
 
-          <h3 className='text-base sm:text-lg font-semibold mb-2 text-primary hover:text-brand-primary transition-colors line-clamp-2'>
+          <h3 className="text-base sm:text-lg font-semibold mb-2 text-primary hover:text-brand-primary transition-colors line-clamp-2">
             {news.title}
           </h3>
 
-          <div className='flex flex-wrap items-center gap-x-4 gap-y-2 text-xs sm:text-sm text-secondary'>
-            <div className='flex items-center gap-1'>
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs sm:text-sm text-secondary">
+            <div className="flex items-center gap-1">
               <Newspaper className="w-4 h-4 text-text-secondary" />
               <span>{news.source}</span>
             </div>
-            <div className='flex items-center gap-1'>
+            <div className="flex items-center gap-1">
               <Calendar className="w-4 h-4 text-text-secondary" />
               <span>{news.publishedAt}</span>
             </div>
           </div>
         </div>
 
-        <ExternalLink className='w-5 h-5 text-secondary flex-shrink-0 mt-1' />
+        <ExternalLink className="w-5 h-5 text-secondary flex-shrink-0 mt-1" />
       </div>
     </Card>
   </a>

--- a/src/components/dashboard/NewsCard.tsx
+++ b/src/components/dashboard/NewsCard.tsx
@@ -27,12 +27,12 @@ export const NewsCard = ({ news }: NewsCardProps) => (
 
           <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs sm:text-sm text-secondary">
             <div className="flex items-center gap-1">
-              <Newspaper className="w-4 h-4 text-text-secondary" />
-              <span>{news.source}</span>
+              <Newspaper className="w-4 h-4 text-text-tertiary" />
+              <span className="text-text-tertiary">{news.source}</span>
             </div>
             <div className="flex items-center gap-1">
-              <Calendar className="w-4 h-4 text-text-secondary" />
-              <span>{news.publishedAt}</span>
+              <Calendar className="w-4 h-4 text-text-tertiary" />
+              <span className="text-text-tertiary">{news.publishedAt}</span>
             </div>
           </div>
         </div>

--- a/src/components/interest/InterestCountryModal.tsx
+++ b/src/components/interest/InterestCountryModal.tsx
@@ -3,11 +3,12 @@ import { Globe } from 'lucide-react';
 import { Modal } from '@/components/common/Modal';
 import { INTEREST_COUNTRIES } from '@/constants/interestCountries';
 import { cn } from '@/lib/utils';
+import type { CountryCode } from '@/types/country';
 
 type InterestCountryModalProps = {
   open: boolean;
-  initialSelected: string[];
-  onSave: (selected: string[]) => void;
+  initialSelected: CountryCode[];
+  onSave: (selected: CountryCode[]) => void;
   onSkip: () => void;
 };
 
@@ -19,7 +20,7 @@ export const InterestCountryModal = ({
   onSave,
   onSkip,
 }: InterestCountryModalProps) => {
-  const [selected, setSelected] = useState<string[]>(initialSelected);
+  const [selected, setSelected] = useState<CountryCode[]>(initialSelected);
 
   useEffect(() => {
     if (open) {
@@ -27,7 +28,7 @@ export const InterestCountryModal = ({
     }
   }, [initialSelected, open]);
 
-  // 단일 토글로 선택/해제를 관리한다. (동일 코드는 setState 배열 필터/추가)
+  // 단일 토글로 선택/해제 관리 (동일 코드는 setState 배열 필터/추가)
   const toggleCountry = (code: string) => {
     setSelected((prev) =>
       prev.includes(code)

--- a/src/components/interest/InterestCountryModal.tsx
+++ b/src/components/interest/InterestCountryModal.tsx
@@ -53,7 +53,7 @@ export const InterestCountryModal = ({
       bodyClassName="relative flex-1 px-8 pb-4 pt-8 sm:px-10 sm:pt-10"
       footerClassName="border-none bg-white px-10 pb-8 pt-4"
       contentClassName="relative border border-border-base shadow-[0_22px_80px_rgba(0,0,0,0.14)]"
-      widthClass="w-[720px] max-w-[720px] min-h-[620px]"
+      widthClass="w-full max-w-[720px] min-h-[620px]"
     >
       <div className="flex flex-col items-center text-center">
         <div className="mb-6 flex h-14 w-14 items-center justify-center rounded-full border border-brand-surface bg-brand-surface text-brand-primary">

--- a/src/components/interest/InterestCountryModal.tsx
+++ b/src/components/interest/InterestCountryModal.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Globe } from 'lucide-react';
+import { Modal } from '@/components/common/Modal';
+import { INTEREST_COUNTRIES } from '@/constants/interestCountries';
+import { cn } from '@/lib/utils';
+
+type InterestCountryModalProps = {
+  open: boolean;
+  initialSelected: string[];
+  onSave: (selected: string[]) => void;
+  onSkip: () => void;
+};
+
+const formatSelectionLabel = (count: number) => `완료 (${count}개 선택)`;
+
+export const InterestCountryModal = ({
+  open,
+  initialSelected,
+  onSave,
+  onSkip,
+}: InterestCountryModalProps) => {
+  const [selected, setSelected] = useState<string[]>(initialSelected);
+
+  useEffect(() => {
+    if (open) {
+      setSelected(initialSelected);
+    }
+  }, [initialSelected, open]);
+
+  const toggleCountry = (code: string) => {
+    setSelected((prev) =>
+      prev.includes(code)
+        ? prev.filter((item) => item !== code)
+        : [...prev, code],
+    );
+  };
+
+  const handleSubmit = () => {
+    if (selected.length === 0) return;
+    onSave(selected);
+  };
+
+  const selectedCount = useMemo(() => selected.length, [selected]);
+
+  return (
+    <Modal
+      open={open}
+      onClose={onSkip}
+      showCloseButton={false}
+      headerClassName="hidden"
+      bodyClassName="relative flex-1 px-8 pb-4 pt-8 sm:px-10 sm:pt-10"
+      footerClassName="border-none bg-white px-10 pb-8 pt-4"
+      contentClassName="relative border border-border-base shadow-[0_22px_80px_rgba(0,0,0,0.14)]"
+      widthClass="w-[720px] max-w-[720px] min-h-[620px]"
+    >
+      <div className="flex flex-col items-center text-center">
+        <div className="mb-6 flex h-14 w-14 items-center justify-center rounded-full border border-brand-surface bg-brand-surface text-brand-primary">
+          <Globe className="h-8 w-8" strokeWidth={2.1} />
+        </div>
+        <h2 className="text-[22px] font-extrabold leading-tight text-text-title sm:text-[24px]">
+          G.law에 오신 것을 환영합니다!
+        </h2>
+        <p className="mt-2 text-[14px] leading-[21px] text-text-body sm:text-[15px]">
+          관심 국가를 선택하시면 맞춤형 법률 정보를 제공해드립니다.
+        </p>
+      </div>
+
+      <div className="mt-8 grid w-full max-w-[660px] grid-cols-3 gap-3 sm:gap-4">
+        {INTEREST_COUNTRIES.map((country) => {
+          const isSelected = selected.includes(country.code);
+          return (
+            <button
+              key={country.code}
+              type="button"
+              onClick={() => toggleCountry(country.code)}
+              className={cn(
+                'flex h-[56px] w-full items-center gap-3 rounded-xl border border-border-base bg-white px-4 text-left transition',
+                'shadow-[0_1px_2px_rgba(0,0,0,0.04)] hover:border-brand-surface hover:shadow-[0_8px_20px_rgba(15,23,42,0.12)]',
+                isSelected &&
+                  'border-state-selected-border bg-brand-light ring-2 ring-state-selected-border ring-offset-0',
+              )}
+              aria-pressed={isSelected}
+            >
+              <span className="text-lg sm:text-xl">{country.flag}</span>
+              <span className="text-[15px] font-semibold text-text-title sm:text-base">
+                {country.name}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mt-9 flex w-full max-w-[660px] flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+        <button
+          type="button"
+          onClick={onSkip}
+          className="min-h-[36px] w-[305px] min-w-[305px] rounded-lg border border-border-base bg-white px-4 py-2 text-[15px] font-semibold text-text-secondary transition hover:bg-bg-soft"
+        >
+          나중에 설정
+        </button>
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={selectedCount === 0}
+          className={cn(
+            'min-h-[36px] w-[305px] min-w-[305px] rounded-lg px-4 py-2 text-[15px] font-semibold text-white transition',
+            selectedCount === 0
+              ? 'bg-border-base text-text-tertiary hover:bg-bg-soft disabled:cursor-not-allowed'
+              : 'bg-state-selected-black hover:bg-text-primary',
+          )}
+        >
+          {formatSelectionLabel(selectedCount)}
+        </button>
+      </div>
+    </Modal>
+  );
+};
+
+export default InterestCountryModal;

--- a/src/components/interest/InterestCountryModal.tsx
+++ b/src/components/interest/InterestCountryModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Globe } from 'lucide-react';
 import { Modal } from '@/components/common/Modal';
 import { INTEREST_COUNTRIES } from '@/constants/interestCountries';
@@ -42,7 +42,7 @@ export const InterestCountryModal = ({
     onSave(selected);
   };
 
-  const selectedCount = useMemo(() => selected.length, [selected]);
+  const selectedCount = selected.length;
 
   return (
     <Modal

--- a/src/components/interest/InterestCountryModal.tsx
+++ b/src/components/interest/InterestCountryModal.tsx
@@ -29,7 +29,7 @@ export const InterestCountryModal = ({
   }, [initialSelected, open]);
 
   // 단일 토글로 선택/해제 관리 (동일 코드는 setState 배열 필터/추가)
-  const toggleCountry = (code: string) => {
+  const toggleCountry = (code: CountryCode) => {
     setSelected((prev) =>
       prev.includes(code)
         ? prev.filter((item) => item !== code)

--- a/src/components/interest/InterestCountryModal.tsx
+++ b/src/components/interest/InterestCountryModal.tsx
@@ -27,6 +27,7 @@ export const InterestCountryModal = ({
     }
   }, [initialSelected, open]);
 
+  // 단일 토글로 선택/해제를 관리한다. (동일 코드는 setState 배열 필터/추가)
   const toggleCountry = (code: string) => {
     setSelected((prev) =>
       prev.includes(code)

--- a/src/components/interest/InterestCountryModal.tsx
+++ b/src/components/interest/InterestCountryModal.tsx
@@ -96,7 +96,7 @@ export const InterestCountryModal = ({
         <button
           type="button"
           onClick={onSkip}
-          className="min-h-[36px] w-[305px] min-w-[305px] rounded-lg border border-border-base bg-white px-4 py-2 text-[15px] font-semibold text-text-secondary transition hover:bg-bg-soft"
+          className="min-h-[36px] w-full sm:w-[305px] sm:min-w-[305px] rounded-lg border border-border-base bg-white px-4 py-2 text-[15px] font-semibold text-text-secondary transition hover:bg-bg-soft"
         >
           나중에 설정
         </button>
@@ -105,7 +105,7 @@ export const InterestCountryModal = ({
           onClick={handleSubmit}
           disabled={selectedCount === 0}
           className={cn(
-            'min-h-[36px] w-[305px] min-w-[305px] rounded-lg px-4 py-2 text-[15px] font-semibold text-white transition',
+            'min-h-[36px] w-full sm:w-[305px] sm:min-w-[305px] rounded-lg px-4 py-2 text-[15px] font-semibold text-white transition',
             selectedCount === 0
               ? 'bg-border-base text-text-tertiary hover:bg-bg-soft disabled:cursor-not-allowed'
               : 'bg-state-selected-black hover:bg-text-primary',

--- a/src/constants/interestCountries.ts
+++ b/src/constants/interestCountries.ts
@@ -1,0 +1,20 @@
+export type InterestCountry = {
+  code: string;
+  name: string;
+  flag: string;
+};
+
+export const INTEREST_COUNTRIES: InterestCountry[] = [
+  { code: 'US', name: '미국', flag: '🇺🇸' },
+  { code: 'JP', name: '일본', flag: '🇯🇵' },
+  { code: 'CN', name: '중국', flag: '🇨🇳' },
+  { code: 'GB', name: '영국', flag: '🇬🇧' },
+  { code: 'FR', name: '프랑스', flag: '🇫🇷' },
+  { code: 'DE', name: '독일', flag: '🇩🇪' },
+  { code: 'TH', name: '태국', flag: '🇹🇭' },
+  { code: 'VN', name: '베트남', flag: '🇻🇳' },
+  { code: 'SG', name: '싱가포르', flag: '🇸🇬' },
+  { code: 'AU', name: '호주', flag: '🇦🇺' },
+  { code: 'CA', name: '캐나다', flag: '🇨🇦' },
+  { code: 'ES', name: '스페인', flag: '🇪🇸' },
+];

--- a/src/constants/interestCountries.ts
+++ b/src/constants/interestCountries.ts
@@ -4,6 +4,7 @@ export type InterestCountry = {
   flag: string;
 };
 
+// 관심 국가 선택 모달과 뉴스 필터에서 사용하는 ISO 국가 코드 순서형 데이터
 export const INTEREST_COUNTRIES: InterestCountry[] = [
   { code: 'US', name: '미국', flag: '🇺🇸' },
   { code: 'JP', name: '일본', flag: '🇯🇵' },

--- a/src/constants/interestCountries.ts
+++ b/src/constants/interestCountries.ts
@@ -18,4 +18,6 @@ export const INTEREST_COUNTRIES: InterestCountry[] = [
   { code: 'AU', name: '호주', flag: '🇦🇺' },
   { code: 'CA', name: '캐나다', flag: '🇨🇦' },
   { code: 'ES', name: '스페인', flag: '🇪🇸' },
-];
+] as const;
+
+export type InterestCountryCode = (typeof INTEREST_COUNTRIES)[number]['code'];

--- a/src/hooks/useFilteredNews.ts
+++ b/src/hooks/useFilteredNews.ts
@@ -1,9 +1,10 @@
 import { useMemo } from 'react';
+import type { CountryCode } from '@/types/country';
 import type { NewsItem } from '@/types/news';
 
 export const useFilteredNews = (
   news: NewsItem[],
-  userInterests: string[],
+  userInterests: CountryCode[],
   selectedTab: string,
 ) => {
   const filteredNewsByCountry: NewsItem[] = useMemo(

--- a/src/hooks/usePreferredCountries.ts
+++ b/src/hooks/usePreferredCountries.ts
@@ -29,9 +29,7 @@ export const usePreferredCountries = () => {
     useState<PreferredCountries>(getInitialPreferredCountries);
 
   const savePreferredCountries = useCallback((countries: CountryCode[]) => {
-    const normalized = Array.from(
-      new Set(countries.map((c) => c.toUpperCase())),
-    );
+    const normalized = Array.from(new Set(countries));
 
     setPreferredCountries(normalized);
     if (typeof window !== 'undefined') {

--- a/src/hooks/usePreferredCountries.ts
+++ b/src/hooks/usePreferredCountries.ts
@@ -16,7 +16,7 @@ const getInitialPreferredCountries = (): PreferredCountries => {
   try {
     const parsed = JSON.parse(stored) as unknown;
     if (Array.isArray(parsed)) {
-      return parsed.filter(isValidCountryCode).map((code) => code);
+      return parsed.filter(isValidCountryCode);
     }
     return [];
   } catch {

--- a/src/hooks/usePreferredCountries.ts
+++ b/src/hooks/usePreferredCountries.ts
@@ -1,7 +1,12 @@
 import { useCallback, useMemo, useState } from 'react';
 import type { CountryCode, PreferredCountries } from '@/types/country';
+import { INTEREST_COUNTRIES } from '@/constants/interestCountries';
 
 const STORAGE_KEY = 'preferredCountries';
+const VALID_CODES = new Set(INTEREST_COUNTRIES.map((c) => c.code));
+
+const isValidCountryCode = (code: unknown): code is CountryCode =>
+  typeof code === 'string' && VALID_CODES.has(code.toUpperCase());
 
 const getInitialPreferredCountries = (): PreferredCountries => {
   if (typeof window === 'undefined') return [];
@@ -12,7 +17,7 @@ const getInitialPreferredCountries = (): PreferredCountries => {
     const parsed = JSON.parse(stored) as unknown;
     if (Array.isArray(parsed)) {
       return parsed
-        .filter((code): code is CountryCode => typeof code === 'string')
+        .filter(isValidCountryCode)
         .map((code) => code.toUpperCase());
     }
     return [];
@@ -22,9 +27,8 @@ const getInitialPreferredCountries = (): PreferredCountries => {
 };
 
 export const usePreferredCountries = () => {
-  const [preferredCountries, setPreferredCountries] = useState<PreferredCountries>(
-    getInitialPreferredCountries,
-  );
+  const [preferredCountries, setPreferredCountries] =
+    useState<PreferredCountries>(getInitialPreferredCountries);
 
   const savePreferredCountries = useCallback((countries: CountryCode[]) => {
     const normalized = Array.from(new Set(countries));

--- a/src/hooks/usePreferredCountries.ts
+++ b/src/hooks/usePreferredCountries.ts
@@ -16,9 +16,7 @@ const getInitialPreferredCountries = (): PreferredCountries => {
   try {
     const parsed = JSON.parse(stored) as unknown;
     if (Array.isArray(parsed)) {
-      return parsed
-        .filter(isValidCountryCode)
-        .map((code) => code.toUpperCase());
+      return parsed.filter(isValidCountryCode).map((code) => code);
     }
     return [];
   } catch {

--- a/src/hooks/usePreferredCountries.ts
+++ b/src/hooks/usePreferredCountries.ts
@@ -31,7 +31,9 @@ export const usePreferredCountries = () => {
     useState<PreferredCountries>(getInitialPreferredCountries);
 
   const savePreferredCountries = useCallback((countries: CountryCode[]) => {
-    const normalized = Array.from(new Set(countries));
+    const normalized = Array.from(
+      new Set(countries.map((c) => c.toUpperCase())),
+    );
 
     setPreferredCountries(normalized);
     if (typeof window !== 'undefined') {

--- a/src/hooks/usePreferredCountries.ts
+++ b/src/hooks/usePreferredCountries.ts
@@ -1,0 +1,59 @@
+import { useCallback, useMemo, useState } from 'react';
+
+const STORAGE_KEY = 'preferredCountries';
+
+const getInitialPreferredCountries = (): string[] => {
+  if (typeof window === 'undefined') return [];
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (!stored) return [];
+
+  try {
+    const parsed = JSON.parse(stored) as unknown;
+    if (Array.isArray(parsed)) {
+      return parsed
+        .filter((code): code is string => typeof code === 'string')
+        .map((code) => code.toUpperCase());
+    }
+    return [];
+  } catch {
+    return [];
+  }
+};
+
+export const usePreferredCountries = () => {
+  const [preferredCountries, setPreferredCountries] = useState<string[]>(
+    getInitialPreferredCountries,
+  );
+
+  const savePreferredCountries = useCallback((countries: string[]) => {
+    const normalized = Array.from(
+      new Set(countries.map((code) => code.toUpperCase())),
+    );
+
+    setPreferredCountries(normalized);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(normalized));
+    }
+  }, []);
+
+  const clearPreferredCountries = useCallback(() => {
+    setPreferredCountries([]);
+    if (typeof window !== 'undefined') {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  const hasPreferredCountries = useMemo(
+    () => preferredCountries.length > 0,
+    [preferredCountries],
+  );
+
+  return {
+    preferredCountries,
+    savePreferredCountries,
+    clearPreferredCountries,
+    hasPreferredCountries,
+  };
+};
+
+export default usePreferredCountries;

--- a/src/hooks/usePreferredCountries.ts
+++ b/src/hooks/usePreferredCountries.ts
@@ -1,8 +1,9 @@
 import { useCallback, useMemo, useState } from 'react';
+import type { CountryCode, PreferredCountries } from '@/types/country';
 
 const STORAGE_KEY = 'preferredCountries';
 
-const getInitialPreferredCountries = (): string[] => {
+const getInitialPreferredCountries = (): PreferredCountries => {
   if (typeof window === 'undefined') return [];
   const stored = window.localStorage.getItem(STORAGE_KEY);
   if (!stored) return [];
@@ -11,7 +12,7 @@ const getInitialPreferredCountries = (): string[] => {
     const parsed = JSON.parse(stored) as unknown;
     if (Array.isArray(parsed)) {
       return parsed
-        .filter((code): code is string => typeof code === 'string')
+        .filter((code): code is CountryCode => typeof code === 'string')
         .map((code) => code.toUpperCase());
     }
     return [];
@@ -21,14 +22,12 @@ const getInitialPreferredCountries = (): string[] => {
 };
 
 export const usePreferredCountries = () => {
-  const [preferredCountries, setPreferredCountries] = useState<string[]>(
+  const [preferredCountries, setPreferredCountries] = useState<PreferredCountries>(
     getInitialPreferredCountries,
   );
 
-  const savePreferredCountries = useCallback((countries: string[]) => {
-    const normalized = Array.from(
-      new Set(countries.map((code) => code.toUpperCase())),
-    );
+  const savePreferredCountries = useCallback((countries: CountryCode[]) => {
+    const normalized = Array.from(new Set(countries));
 
     setPreferredCountries(normalized);
     if (typeof window !== 'undefined') {

--- a/src/hooks/usePreferredCountries.ts
+++ b/src/hooks/usePreferredCountries.ts
@@ -5,7 +5,7 @@ import { INTEREST_COUNTRIES } from '@/constants/interestCountries';
 const STORAGE_KEY = 'preferredCountries';
 const VALID_CODES = new Set(INTEREST_COUNTRIES.map((c) => c.code));
 
-const isValidCountryCode = (code: unknown): code is CountryCode =>
+const isValidCountryCode = (code: unknown): code is string =>
   typeof code === 'string' && VALID_CODES.has(code.toUpperCase());
 
 const getInitialPreferredCountries = (): PreferredCountries => {
@@ -16,7 +16,9 @@ const getInitialPreferredCountries = (): PreferredCountries => {
   try {
     const parsed = JSON.parse(stored) as unknown;
     if (Array.isArray(parsed)) {
-      return parsed.filter(isValidCountryCode);
+      return parsed
+        .filter(isValidCountryCode)
+        .map((code) => code.toUpperCase());
     }
     return [];
   } catch {

--- a/src/pages/ui/MainDashboardPage.tsx
+++ b/src/pages/ui/MainDashboardPage.tsx
@@ -81,7 +81,7 @@ export const MainDashboardPage = ({
                 value="all"
                 activeTab={selectedTab}
                 news={newsToShow}
-                emptyMessage="선택하신 국가의 최신 이슈가 없습니다."
+                emptyMessage="현재 등록된 해외 이슈가 없습니다."
               />
 
               {/* 관심 국가 이슈 리스트 */}

--- a/src/pages/ui/MainDashboardPage.tsx
+++ b/src/pages/ui/MainDashboardPage.tsx
@@ -43,7 +43,7 @@ export const MainDashboardPage = ({
         {/* 페이지 타이틀 영역 */}
         <header className="mt-6 sm:mt-8 mb-8 pl-4 sm:pl-6 lg:pl-8">
           <div className="flex items-center gap-3 mb-1">
-            <Globe className="w-7 h-7 text-brand-primary" />
+            <Globe className="w-9 h-9 text-brand-primary" strokeWidth={2.2} />
             <h1 className="text-[28px] font-medium leading-tight text-text-primary sm:text-[32px]">
               해외 이슈 대시보드
             </h1>

--- a/src/pages/ui/MainDashboardPage.tsx
+++ b/src/pages/ui/MainDashboardPage.tsx
@@ -8,16 +8,22 @@ import {
 import { FilteredNewsList } from '@/components/dashboard/FilteredNewsList';
 import { useTabsState } from '@/hooks/useTabsState';
 import { useFilteredNews } from '@/hooks/useFilteredNews';
-import { mockNews, mockUserInterests } from '@/mocks/news';
+import { mockNews } from '@/mocks/news';
 import type { NewsItem } from '@/types/news';
 
 /**
  * @description 글로벌 정책/법률 변경 대시보드 메인 컴포넌트
  */
-export const MainDashboardPage = () => {
-  // 실제 API 연동 시 mockNews, mockUserInterests 대체
+type MainDashboardPageProps = {
+  preferredCountries: string[];
+};
+
+export const MainDashboardPage = ({
+  preferredCountries,
+}: MainDashboardPageProps) => {
+  // 실제 API 연동 시 mockNews 대체
   const news: NewsItem[] = mockNews;
-  const userInterests: string[] = mockUserInterests;
+  const userInterests: string[] = preferredCountries;
 
   const { selectedTab, onChangeTab } = useTabsState(news);
 
@@ -38,55 +44,58 @@ export const MainDashboardPage = () => {
         <header className="mt-6 sm:mt-8 mb-8 pl-4 sm:pl-6 lg:pl-8">
           <div className="flex items-center gap-3 mb-1">
             <Globe className="w-7 h-7 text-brand-primary" />
-            <h1 className="text-2xl sm:text-3xl font-extrabold text-primary">
-            해외 이슈 대시보드
-          </h1>
+            <h1 className="text-[28px] font-medium leading-tight text-text-primary sm:text-[32px]">
+              해외 이슈 대시보드
+            </h1>
           </div>
           <p className="text-sm sm:text-base text-text-secondary">
             해외 주요 법률 및 정책 개정 소식을 확인하세요.
           </p>
         </header>
 
+        {/* 회색 배경 전체 영역 */}
+        <div className="bg-[#F2F4F6]">
+          {/* 중앙 컨텐츠 영역 max-width 적용 */}
+          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-8">
+            {/* 탭 + 리스트 영역 */}
+            <DashboardTabs
+              defaultValue="all"
+              value={selectedTab}
+              onValueChange={onChangeTab}
+            >
+              {/* 전체 / 관심 국가 탭 */}
+              <DashboardTabsList className="mb-6 flex flex-wrap">
+                <DashboardTabsTrigger value="all">
+                  <Globe className="w-4 h-4 mr-2" />
+                  전체 이슈 ({news.length})
+                </DashboardTabsTrigger>
 
-          {/* 회색 배경 전체 영역 */}
-          <div className="bg-[#F2F4F6]">
-            {/* 중앙 컨텐츠 영역 max-width 적용 */}
-            <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-8">
-        {/* 탭 + 리스트 영역 */}
-        <DashboardTabs defaultValue="all" onValueChange={onChangeTab}>
-          {/* 전체 / 관심 국가 탭 */}
-          <DashboardTabsList className="mb-6 flex flex-wrap">
-            <DashboardTabsTrigger value="all">
-              <Globe className="w-4 h-4 mr-2" />
-              전체 이슈 ({news.length})
-            </DashboardTabsTrigger>
+                <DashboardTabsTrigger value="interests">
+                  <User className="w-4 h-4 mr-2 text-[#6B7280]" />
+                  관심 국가 이슈 ({interestNews.length})
+                </DashboardTabsTrigger>
+              </DashboardTabsList>
 
-            <DashboardTabsTrigger value="interests">
-              <User className="w-4 h-4 mr-2 text-[#6B7280]" />
-              관심 국가 이슈 ({interestNews.length})
-            </DashboardTabsTrigger>
-          </DashboardTabsList>
+              {/* 전체 이슈 리스트 */}
+              <FilteredNewsList
+                value="all"
+                activeTab={selectedTab}
+                news={newsToShow}
+                emptyMessage="선택하신 국가의 최신 이슈가 없습니다."
+              />
 
-          {/* 전체 이슈 리스트 */}
-          <FilteredNewsList
-            value="all"
-            activeTab={selectedTab}
-            news={newsToShow}
-            emptyMessage="선택하신 국가의 최신 이슈가 없습니다."
-          />
-
-          {/* 관심 국가 이슈 리스트 */}
-          <FilteredNewsList
-            value="interests"
-            activeTab={selectedTab}
-            news={interestNews}
-            emptyMessage="설정한 관심 국가에 해당하는 최신 이슈가 없습니다."
-          />
-        </DashboardTabs>
-        </div>
+              {/* 관심 국가 이슈 리스트 */}
+              <FilteredNewsList
+                value="interests"
+                activeTab={selectedTab}
+                news={interestNews}
+                emptyMessage="설정한 관심 국가에 해당하는 최신 이슈가 없습니다."
+              />
+            </DashboardTabs>
           </div>
+        </div>
       </main>
-      </div>
+    </div>
   );
 };
 

--- a/src/pages/ui/MainDashboardPage.tsx
+++ b/src/pages/ui/MainDashboardPage.tsx
@@ -10,12 +10,13 @@ import { useTabsState } from '@/hooks/useTabsState';
 import { useFilteredNews } from '@/hooks/useFilteredNews';
 import { mockNews } from '@/mocks/news';
 import type { NewsItem } from '@/types/news';
+import type { PreferredCountries } from '@/types/country';
 
 /**
  * @description 글로벌 정책/법률 변경 대시보드 메인 컴포넌트
  */
 type MainDashboardPageProps = {
-  preferredCountries: string[];
+  preferredCountries: PreferredCountries;
 };
 
 export const MainDashboardPage = ({

--- a/src/pages/ui/MainDashboardPage.tsx
+++ b/src/pages/ui/MainDashboardPage.tsx
@@ -54,7 +54,7 @@ export const MainDashboardPage = ({
         </header>
 
         {/* 회색 배경 전체 영역 */}
-        <div className="bg-[#F2F4F6]">
+        <div className="bg-bg-soft">
           {/* 중앙 컨텐츠 영역 max-width 적용 */}
           <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-8">
             {/* 탭 + 리스트 영역 */}
@@ -71,7 +71,7 @@ export const MainDashboardPage = ({
                 </DashboardTabsTrigger>
 
                 <DashboardTabsTrigger value="interests">
-                  <User className="w-4 h-4 mr-2 text-[#6B7280]" />
+                  <User className="w-4 h-4 mr-2 text-text-tertiary" />
                   관심 국가 이슈 ({interestNews.length})
                 </DashboardTabsTrigger>
               </DashboardTabsList>

--- a/src/pages/ui/MainDashboardPage.tsx
+++ b/src/pages/ui/MainDashboardPage.tsx
@@ -25,6 +25,10 @@ export const MainDashboardPage = ({
   // 실제 API 연동 시 mockNews 대체
   const news: NewsItem[] = mockNews;
   const userInterests: string[] = preferredCountries;
+  const hasPreferredCountries = preferredCountries.length > 0;
+  const interestEmptyMessage = hasPreferredCountries
+    ? '설정한 관심 국가에 해당하는 최신 이슈가 없습니다.'
+    : '설정된 관심 국가가 없습니다. 관심 국가를 설정해 주세요.';
 
   const { selectedTab, onChangeTab } = useTabsState(news);
 
@@ -90,7 +94,7 @@ export const MainDashboardPage = ({
                 value="interests"
                 activeTab={selectedTab}
                 news={interestNews}
-                emptyMessage="설정한 관심 국가에 해당하는 최신 이슈가 없습니다."
+                emptyMessage={interestEmptyMessage}
               />
             </DashboardTabs>
           </div>

--- a/src/pages/ui/MainDashboardPage.tsx
+++ b/src/pages/ui/MainDashboardPage.tsx
@@ -24,7 +24,7 @@ export const MainDashboardPage = ({
 }: MainDashboardPageProps) => {
   // 실제 API 연동 시 mockNews 대체
   const news: NewsItem[] = mockNews;
-  const userInterests: string[] = preferredCountries;
+  const userInterests = preferredCountries;
   const hasPreferredCountries = preferredCountries.length > 0;
   const interestEmptyMessage = hasPreferredCountries
     ? '설정한 관심 국가에 해당하는 최신 이슈가 없습니다.'

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -1,21 +1,115 @@
-import { Navigate, createBrowserRouter } from 'react-router-dom';
-import { ExamplePage } from '@/pages/ui/ExamplePage';
+import { useEffect, useState } from 'react';
+import { Navigate, Route, Routes, useNavigate } from 'react-router-dom';
+import { MainDashboardPage } from '@/pages/ui/MainDashboardPage';
+import { LawCollectionPage } from '@/pages/ui/LawCollectionPage';
 import { LoginPage } from '@/pages/ui/LoginPage';
+import { InterestCountryModal } from '@/components/interest/InterestCountryModal';
+import { usePreferredCountries } from '@/hooks/usePreferredCountries';
+import { Header } from '@/components/layout/Header';
 
-const LoginRoute = () => {
+const HeaderOnlyPage = () => (
+  <div className="min-h-screen bg-surface font-sans">
+    <Header />
+  </div>
+);
+
+export const AppRoutes = () => {
+  const navigate = useNavigate();
+  const { preferredCountries, savePreferredCountries, hasPreferredCountries } =
+    usePreferredCountries();
+
+  const [isLoggedIn, setIsLoggedIn] = useState(() => hasPreferredCountries);
+  const [isInterestModalOpen, setIsInterestModalOpen] = useState(false);
+  const [modalSelection, setModalSelection] =
+    useState<string[]>(preferredCountries);
+
+  useEffect(() => {
+    if (hasPreferredCountries) {
+      setIsLoggedIn(true);
+      setModalSelection(preferredCountries);
+    }
+  }, [hasPreferredCountries, preferredCountries]);
+
   const handleGoogleLogin = () => {
-    console.log('Google 로그인 버튼 클릭!');
+    setIsLoggedIn(true);
+    if (!hasPreferredCountries) {
+      setModalSelection(preferredCountries);
+      setIsInterestModalOpen(true);
+    }
+    void navigate('/');
   };
 
-  return <LoginPage onGoogleLogin={handleGoogleLogin} />;
+  const handleSkipInterest = () => {
+    setIsInterestModalOpen(false);
+  };
+
+  const handleSaveInterest = (countries: string[]) => {
+    savePreferredCountries(countries);
+    setIsInterestModalOpen(false);
+  };
+
+  return (
+    <>
+      <Routes>
+        <Route
+          path="/"
+          element={
+            isLoggedIn ? (
+              <MainDashboardPage preferredCountries={preferredCountries} />
+            ) : (
+              <Navigate to="/login" replace />
+            )
+          }
+        />
+        <Route
+          path="/login"
+          element={
+            isLoggedIn ? (
+              <Navigate to="/" replace />
+            ) : (
+              <LoginPage onGoogleLogin={handleGoogleLogin} />
+            )
+          }
+        />
+        <Route
+          path="/law-collection"
+          element={
+            isLoggedIn ? (
+              <LawCollectionPage />
+            ) : (
+              <Navigate to="/login" replace />
+            )
+          }
+        />
+        <Route
+          path="/ai-consulting"
+          element={
+            isLoggedIn ? <HeaderOnlyPage /> : <Navigate to="/login" replace />
+          }
+        />
+        <Route
+          path="/law-compare"
+          element={
+            isLoggedIn ? <HeaderOnlyPage /> : <Navigate to="/login" replace />
+          }
+        />
+        <Route
+          path="/mypage"
+          element={
+            isLoggedIn ? <HeaderOnlyPage /> : <Navigate to="/login" replace />
+          }
+        />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+
+      <InterestCountryModal
+        open={isInterestModalOpen}
+        initialSelected={modalSelection}
+        onSkip={handleSkipInterest}
+        onSave={handleSaveInterest}
+      />
+    </>
+  );
 };
 
-/** 앱 라우트 정의 (RouterProvider에서 사용) */
-export const appRouter = createBrowserRouter([
-  { path: '/', element: <LoginRoute /> },
-  { path: '/law-collection', element: <ExamplePage /> },
-  { path: '/ai-consulting', element: <ExamplePage /> },
-  { path: '/law-compare', element: <ExamplePage /> },
-  { path: '/mypage', element: <ExamplePage /> },
-  { path: '*', element: <Navigate to="/" replace /> },
-]);
+export default AppRoutes;

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -6,6 +6,7 @@ import { LoginPage } from '@/pages/ui/LoginPage';
 import { InterestCountryModal } from '@/components/interest/InterestCountryModal';
 import { usePreferredCountries } from '@/hooks/usePreferredCountries';
 import { Header } from '@/components/layout/Header';
+import { CountryCode } from '@/types/country';
 
 const HeaderOnlyPage = () => (
   <div className="min-h-screen bg-surface font-sans">
@@ -44,7 +45,7 @@ export const AppRoutes = () => {
     setIsInterestModalOpen(false);
   };
 
-  const handleSaveInterest = (countries: string[]) => {
+  const handleSaveInterest = (countries: CountryCode[]) => {
     savePreferredCountries(countries);
     setIsInterestModalOpen(false);
   };

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -20,6 +20,7 @@ export const AppRoutes = () => {
 
   const [isLoggedIn, setIsLoggedIn] = useState(() => hasPreferredCountries);
   const [isInterestModalOpen, setIsInterestModalOpen] = useState(false);
+  // 모달에서만 사용하는 임시 선택값. 저장 시 usePreferredCountries에 반영된다.
   const [modalSelection, setModalSelection] =
     useState<string[]>(preferredCountries);
 

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -20,9 +20,9 @@ export const AppRoutes = () => {
 
   const [isLoggedIn, setIsLoggedIn] = useState(() => hasPreferredCountries);
   const [isInterestModalOpen, setIsInterestModalOpen] = useState(false);
-  // 모달에서만 사용하는 임시 선택값. 저장 시 usePreferredCountries에 반영된다.
-  const [modalSelection, setModalSelection] =
-    useState<string[]>(preferredCountries);
+  // 모달에서만 사용하는 임시 선택값
+  // 저장 시 usePreferredCountries에 반영
+  const [modalSelection, setModalSelection] = useState(preferredCountries);
 
   useEffect(() => {
     if (hasPreferredCountries) {

--- a/src/types/country.ts
+++ b/src/types/country.ts
@@ -1,0 +1,4 @@
+import type { INTEREST_COUNTRIES } from '@/constants/interestCountries';
+
+export type CountryCode = (typeof INTEREST_COUNTRIES)[number]['code'];
+export type PreferredCountries = CountryCode[];

--- a/src/types/news.ts
+++ b/src/types/news.ts
@@ -22,35 +22,6 @@ export type BadgeProps = {
   children: React.ReactNode;
 };
 
-export type DashboardTabsProps = {
-  defaultValue: string;
-  value?: string;
-  onValueChange: (value: string) => void;
-  children: React.ReactNode;
-};
-
-export type DashboardTabsListProps = {
-  className?: string;
-  activeTab?: string;
-  onTabChange?: (value: string) => void;
-  children: React.ReactNode;
-};
-
-export type DashboardTabsTriggerProps = {
-  className?: string;
-  value: string;
-  activeTab?: string;
-  onTabClick?: (value: string) => void;
-  children: React.ReactNode;
-};
-
-export type DashboardTabsContentProps = {
-  className?: string;
-  value: string;
-  activeTab?: string;
-  children: React.ReactNode;
-};
-
 export type NewsCardProps = {
   news: NewsItem;
 };

--- a/src/types/news.ts
+++ b/src/types/news.ts
@@ -4,7 +4,7 @@ export type NewsItem = {
   id: number;
   title: string;
   country: string;
-  countryCode: string; // US, JP, DE, SG, FR, TH
+  countryCode: string; // ISO 2-letter code (예: US, JP, DE, SG, FR, TH)
   source: string;
   sourceUrl: string;
   publishedAt: string;

--- a/src/types/news.ts
+++ b/src/types/news.ts
@@ -24,6 +24,7 @@ export type BadgeProps = {
 
 export type DashboardTabsProps = {
   defaultValue: string;
+  value?: string;
   onValueChange: (value: string) => void;
   children: React.ReactNode;
 };

--- a/src/types/tabs.ts
+++ b/src/types/tabs.ts
@@ -1,0 +1,35 @@
+import type React from 'react';
+
+export type DashboardTabsProps = {
+  defaultValue: string;
+  value?: string;
+  onValueChange: (value: string) => void;
+  children: React.ReactNode;
+};
+
+export type DashboardTabsListProps = {
+  className?: string;
+  activeTab?: string;
+  onTabChange?: (value: string) => void;
+  tabsId?: string;
+  children: React.ReactNode;
+};
+
+export type DashboardTabsTriggerProps = {
+  className?: string;
+  value: string;
+  activeTab?: string;
+  onTabClick?: (value: string) => void;
+  tabId?: string;
+  panelId?: string;
+  children: React.ReactNode;
+};
+
+export type DashboardTabsContentProps = {
+  className?: string;
+  value: string;
+  activeTab?: string;
+  tabId?: string;
+  panelId?: string;
+  children: React.ReactNode;
+};


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #28 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 관심 국가 설정 모달을 피그마 디자인에 맞춰 토큰 기반 색상/레이아웃으로 제작
- 관심 국가를 localStorage로 저장 -> 이슈 대시보드에서 사용
- 메인 이슈 대시보드 화면의 페이지 타이틀 영역, 뱃지 등 UI를 피그마 디자인에 맞춰 수정
- 관련 데이터/타입/라우팅을 관심 국가 흐름에 맞게 정리
<!---- Resolves: #(Isuue Number) -->
<img width="1792" height="1047" alt="image" src="https://github.com/user-attachments/assets/050fbe70-1e33-4e15-b509-c57a877ff741" />
<img width="1792" height="1047" alt="image" src="https://github.com/user-attachments/assets/c4e353d2-229e-46be-9a62-b298910368c2" />


## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 빌드 / 타입 에러 확인을 진행하였습니다.

📣 **To Reviewers**
---
<!-- 전달사항 -->
- firebase나 json-server를 사용해서 임시 백엔드를 구현할까 했는데 우선 이번 발표 때는 서비스 사용 흐름을 보여 주는 게 더 중요할 것 같아서 로그인 버튼을 누르면 바로 관심 국가 설정 모달로 이동하도록 구현했습니다! 
- 국가 목록은 피그마 디자인에 있는 나라 12개 모두 넣어 놨는데... 나라가 추가되면 디자인을 어떻게 해야 할지 고민해 봐야 될 것 같아요 그리고 우선 영어권 나라를 대상으로 서비스를 제공하는 거니까 이슈 대시보드에도 영어권 나라만 보여 줘야 할지 + 관심 국가 설정에 영어권 나라만 포함시켜야 할지 잘 모르겠네요 😓

- Reviewers : 팀원
- Assignees: 자기 자신
- Labels : 작업 유형, 자기 자신

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경 사항

* **새로운 기능**
  * 관심 국가 선택 모달 추가 — 다중 선택 후 저장 또는 건너뛰기 가능
  * 선호 국가 관리 기능 추가 — 선택 정보 로컬에 저장·반영
  * 라우팅 컴포넌트(AppRoutes) 도입 및 인증 기반 내비게이션 추가

* **개선 사항**
  * 대시보드 레이아웃·스타일 업데이트(헤더·배경·아이콘 조정)
  * 탭 컴포넌트 접근성 및 제어/비제어 모드 지원(ARIA, ID 매핑)
  * 뉴스 카드 스타일·마크업 정리

* **타입**
  * 국가·탭 관련 타입 정리 및 useFilteredNews의 userInterests 타입 변경(국가 코드 배열)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->