### PR TITLE
[feat] 법률 리스크 API 연동

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_API_BASE_URL=https://api.glaw.site
+VITE_LEGAL_RISK_PATH=/api/risk

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-VITE_API_BASE_URL=https://glaw-web.duckdns.org/ai
+VITE_API_BASE_URL=/ai
 VITE_LAW_COMPARE_PATH=/api/v1/ai/compare
 VITE_LEGAL_RISK_PATH=/api/risk

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-VITE_API_BASE_URL=/ai
+VITE_API_BASE_URL=https://api.glaw.site/ai
 VITE_LAW_COMPARE_PATH=/api/v1/ai/compare
 VITE_LEGAL_RISK_PATH=/api/risk

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
-VITE_API_BASE_URL=https://api.glaw.site
+VITE_API_BASE_URL=https://glaw-web.duckdns.org/ai
+VITE_LAW_COMPARE_PATH=/api/v1/ai/compare
 VITE_LEGAL_RISK_PATH=/api/risk

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,8 +1,7 @@
 import axios from 'axios';
 
 export const apiClient = axios.create({
-  baseURL:
-    import.meta.env.VITE_API_BASE_URL ?? 'https://glaw-web.duckdns.org/ai',
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? '/ai',
   headers: {
     'Content-Type': 'application/json',
   },

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,7 +1,8 @@
 import axios from 'axios';
 
 export const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL ?? 'https://api.glaw.site',
+  baseURL:
+    import.meta.env.VITE_API_BASE_URL ?? 'https://glaw-web.duckdns.org/ai',
   headers: {
     'Content-Type': 'application/json',
   },

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,8 @@
+import axios from 'axios';
+
+export const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? 'https://api.glaw.site',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});

--- a/src/api/lawComparison.ts
+++ b/src/api/lawComparison.ts
@@ -1,0 +1,57 @@
+import { apiClient } from '@/api/client';
+import type {
+  CompareLawApiResponse,
+  CompareLawRequest,
+} from '@/types/comparison';
+
+const LAW_COMPARE_PATH =
+  import.meta.env.VITE_LAW_COMPARE_PATH ?? '/api/v1/ai/compare';
+
+type HttpError = {
+  response?: {
+    data?: unknown;
+    status?: number;
+  };
+};
+
+const isHttpError = (error: unknown): error is HttpError =>
+  typeof error === 'object' && error !== null && 'response' in error;
+
+export class LawComparisonApiError extends Error {
+  status?: number;
+  code?: string;
+
+  constructor(message: string, status?: number, code?: string) {
+    super(message);
+    this.name = 'LawComparisonApiError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export const compareLaws = async (
+  payload: CompareLawRequest,
+): Promise<CompareLawApiResponse> => {
+  try {
+    const { data } = await apiClient.post<CompareLawApiResponse>(
+      LAW_COMPARE_PATH,
+      payload,
+      { timeout: 120_000 },
+    );
+
+    return data;
+  } catch (error) {
+    if (isHttpError(error)) {
+      const data = error.response?.data as Partial<CompareLawApiResponse> | undefined;
+      throw new LawComparisonApiError(
+        data?.message ?? '법률 비교 요청에 실패했습니다.',
+        data?.status ?? error.response?.status,
+        data?.code,
+      );
+    }
+
+    throw new LawComparisonApiError(
+      '네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+    );
+  }
+};

--- a/src/api/legalRisk.ts
+++ b/src/api/legalRisk.ts
@@ -107,7 +107,8 @@ const normalizeLegalRiskResult = (
   result: LegalRiskRawResult,
   payload: LegalRiskRequest,
 ): LegalRiskResult => {
-  const parsedResult = typeof result === 'string' ? parseStringResult(result) : result;
+  const parsedResult =
+    typeof result === 'string' ? parseStringResult(result) : result;
 
   if (isLegalRiskResult(parsedResult)) {
     return parsedResult;

--- a/src/api/legalRisk.ts
+++ b/src/api/legalRisk.ts
@@ -33,7 +33,21 @@ const isLegalRiskResult = (value: unknown): value is LegalRiskResult => {
   return (
     typeof result.country_id === 'number' &&
     isRiskLevel(result.overall_risk_level) &&
-    Array.isArray(result.risk_list)
+    Array.isArray(result.risk_list) &&
+    result.risk_list.every((risk) => {
+      if (typeof risk !== 'object' || risk === null) {
+        return false;
+      }
+
+      const riskItem = risk as Partial<LegalRiskResult['risk_list'][number]>;
+      return (
+        typeof riskItem.risk_title === 'string' &&
+        isRiskLevel(riskItem.risk_level) &&
+        typeof riskItem.risk_content === 'string' &&
+        Array.isArray(riskItem.risk_actions) &&
+        Array.isArray(riskItem.law_refs)
+      );
+    })
   );
 };
 

--- a/src/api/legalRisk.ts
+++ b/src/api/legalRisk.ts
@@ -4,9 +4,12 @@ import type {
   ApiResponse,
   LegalRiskRequest,
   LegalRiskResult,
+  RiskLevel,
 } from '@/types/legalRisk';
 
 const LEGAL_RISK_PATH = import.meta.env.VITE_LEGAL_RISK_PATH ?? '/api/risk';
+
+type LegalRiskRawResult = LegalRiskResult | string;
 
 type HttpError = {
   response?: {
@@ -17,6 +20,60 @@ type HttpError = {
 
 const isHttpError = (error: unknown): error is HttpError =>
   typeof error === 'object' && error !== null && 'response' in error;
+
+const isRiskLevel = (value: unknown): value is RiskLevel =>
+  value === 'LOW' || value === 'MEDIUM' || value === 'HIGH';
+
+const isLegalRiskResult = (value: unknown): value is LegalRiskResult => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const result = value as Partial<LegalRiskResult>;
+  return (
+    typeof result.country_id === 'number' &&
+    isRiskLevel(result.overall_risk_level) &&
+    Array.isArray(result.risk_list)
+  );
+};
+
+const parseStringResult = (result: string): unknown => {
+  try {
+    return JSON.parse(result);
+  } catch {
+    return result;
+  }
+};
+
+const normalizeLegalRiskResult = (
+  result: LegalRiskRawResult,
+  payload: LegalRiskRequest,
+): LegalRiskResult => {
+  const parsedResult = typeof result === 'string' ? parseStringResult(result) : result;
+
+  if (isLegalRiskResult(parsedResult)) {
+    return parsedResult;
+  }
+
+  if (typeof parsedResult === 'string' && parsedResult.trim()) {
+    return {
+      country_id: payload.country_id,
+      overall_risk_level: 'MEDIUM',
+      risk_list: [
+        {
+          risk_title: '위험 지수 분석 결과',
+          risk_level: 'MEDIUM',
+          risk_content: parsedResult,
+          risk_actions: [],
+          law_refs: [],
+          issue_refs: [],
+        },
+      ],
+    };
+  }
+
+  throw new LegalRiskApiError('위험 지수 응답 형식이 올바르지 않습니다.');
+};
 
 export class LegalRiskApiError extends Error {
   status?: number;
@@ -34,20 +91,20 @@ export const getLegalRisk = async (
   payload: LegalRiskRequest,
 ): Promise<LegalRiskResult> => {
   try {
-    const { data } = await apiClient.post<ApiResponse<LegalRiskResult>>(
+    const { data } = await apiClient.post<ApiResponse<LegalRiskRawResult>>(
       LEGAL_RISK_PATH,
       payload,
     );
 
-    if (!data.success || !data.result) {
+    if (!data.success || data.result === null || data.result === undefined) {
       throw new LegalRiskApiError(
-        data.message || '법률 리스크 조회에 실패했습니다.',
+        data.message || '위험 지수 조회에 실패했습니다.',
         data.status,
         data.code,
       );
     }
 
-    return data.result;
+    return normalizeLegalRiskResult(data.result, payload);
   } catch (error) {
     if (error instanceof LegalRiskApiError) {
       throw error;
@@ -56,12 +113,12 @@ export const getLegalRisk = async (
     if (isHttpError(error)) {
       const data = error.response?.data as ApiErrorResponse | undefined;
       throw new LegalRiskApiError(
-        data?.message ?? '법률 리스크 조회에 실패했습니다.',
+        data?.message ?? '위험 지수 조회에 실패했습니다.',
         data?.status ?? error.response?.status,
         data?.code,
       );
     }
 
-    throw new LegalRiskApiError('법률 리스크 조회 중 오류가 발생했습니다.');
+    throw new LegalRiskApiError('위험 지수 조회 중 오류가 발생했습니다.');
   }
 };

--- a/src/api/legalRisk.ts
+++ b/src/api/legalRisk.ts
@@ -1,0 +1,55 @@
+import { apiClient } from '@/api/client';
+import type {
+  ApiErrorResponse,
+  ApiResponse,
+  LegalRiskRequest,
+  LegalRiskResult,
+} from '@/types/legalRisk';
+
+const LEGAL_RISK_PATH = import.meta.env.VITE_LEGAL_RISK_PATH ?? '/api/risk';
+
+type HttpError = {
+  response?: {
+    data?: unknown;
+    status?: number;
+  };
+};
+
+const isHttpError = (error: unknown): error is HttpError =>
+  typeof error === 'object' && error !== null && 'response' in error;
+
+export class LegalRiskApiError extends Error {
+  status?: number;
+  code?: string;
+
+  constructor(message: string, status?: number, code?: string) {
+    super(message);
+    this.name = 'LegalRiskApiError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export const getLegalRisk = async (
+  payload: LegalRiskRequest,
+): Promise<LegalRiskResult> => {
+  try {
+    const { data } = await apiClient.post<ApiResponse<LegalRiskResult>>(
+      LEGAL_RISK_PATH,
+      payload,
+    );
+
+    return data.result;
+  } catch (error) {
+    if (isHttpError(error)) {
+      const data = error.response?.data as ApiErrorResponse | undefined;
+      throw new LegalRiskApiError(
+        data?.message ?? '법률 리스크 조회에 실패했습니다.',
+        data?.status ?? error.response?.status,
+        data?.code,
+      );
+    }
+
+    throw new LegalRiskApiError('법률 리스크 조회 중 오류가 발생했습니다.');
+  }
+};

--- a/src/api/legalRisk.ts
+++ b/src/api/legalRisk.ts
@@ -39,8 +39,20 @@ export const getLegalRisk = async (
       payload,
     );
 
+    if (!data.success || !data.result) {
+      throw new LegalRiskApiError(
+        data.message || '법률 리스크 조회에 실패했습니다.',
+        data.status,
+        data.code,
+      );
+    }
+
     return data.result;
   } catch (error) {
+    if (error instanceof LegalRiskApiError) {
+      throw error;
+    }
+
     if (isHttpError(error)) {
       const data = error.response?.data as ApiErrorResponse | undefined;
       throw new LegalRiskApiError(

--- a/src/api/legalRisk.ts
+++ b/src/api/legalRisk.ts
@@ -40,7 +40,7 @@ const isLawRefs = (
       LegalRiskResult['risk_list'][number]['law_refs'][number]
     >;
     return (
-      typeof lawRef.law_id === 'number' &&
+      (typeof lawRef.law_id === 'number' || lawRef.law_id === null) &&
       typeof lawRef.law_type === 'string' &&
       typeof lawRef.article_no === 'string'
     );

--- a/src/api/legalRisk.ts
+++ b/src/api/legalRisk.ts
@@ -24,6 +24,49 @@ const isHttpError = (error: unknown): error is HttpError =>
 const isRiskLevel = (value: unknown): value is RiskLevel =>
   value === 'LOW' || value === 'MEDIUM' || value === 'HIGH';
 
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === 'string');
+
+const isLawRefs = (
+  value: unknown,
+): value is LegalRiskResult['risk_list'][number]['law_refs'] =>
+  Array.isArray(value) &&
+  value.every((law) => {
+    if (typeof law !== 'object' || law === null) {
+      return false;
+    }
+
+    const lawRef = law as Partial<
+      LegalRiskResult['risk_list'][number]['law_refs'][number]
+    >;
+    return (
+      typeof lawRef.law_id === 'number' &&
+      typeof lawRef.law_type === 'string' &&
+      typeof lawRef.article_no === 'string'
+    );
+  });
+
+const isIssueRefs = (
+  value: unknown,
+): value is NonNullable<LegalRiskResult['risk_list'][number]['issue_refs']> =>
+  value === undefined ||
+  (Array.isArray(value) &&
+    value.every((issue) => {
+      if (typeof issue !== 'object' || issue === null) {
+        return false;
+      }
+
+      const issueRef = issue as Partial<
+        NonNullable<LegalRiskResult['risk_list'][number]['issue_refs']>[number]
+      >;
+      return (
+        typeof issueRef.issue_id === 'number' &&
+        typeof issueRef.title === 'string' &&
+        typeof issueRef.url === 'string' &&
+        typeof issueRef.published_date === 'string'
+      );
+    }));
+
 const isLegalRiskResult = (value: unknown): value is LegalRiskResult => {
   if (typeof value !== 'object' || value === null) {
     return false;
@@ -44,8 +87,9 @@ const isLegalRiskResult = (value: unknown): value is LegalRiskResult => {
         typeof riskItem.risk_title === 'string' &&
         isRiskLevel(riskItem.risk_level) &&
         typeof riskItem.risk_content === 'string' &&
-        Array.isArray(riskItem.risk_actions) &&
-        Array.isArray(riskItem.law_refs)
+        isStringArray(riskItem.risk_actions) &&
+        isLawRefs(riskItem.law_refs) &&
+        isIssueRefs(riskItem.issue_refs)
       );
     })
   );
@@ -108,6 +152,7 @@ export const getLegalRisk = async (
     const { data } = await apiClient.post<ApiResponse<LegalRiskRawResult>>(
       LEGAL_RISK_PATH,
       payload,
+      { timeout: 120_000 },
     );
 
     if (!data.success || data.result === null || data.result === undefined) {

--- a/src/components/comparison/ComparisonForm.tsx
+++ b/src/components/comparison/ComparisonForm.tsx
@@ -85,7 +85,7 @@ export const ComparisonForm = ({
       {/* 제출 버튼 */}
       <Button
         onClick={onSubmit}
-        disabled={isLoading || !topic || !country1 || !country2}
+        disabled={isLoading || !topic.trim() || !country1 || !country2}
         className="w-full"
       >
         <GitCompare className="mr-2 h-4 w-4" />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -14,7 +14,6 @@ import { MobileMenu } from './MobileMenu';
 import { NavButton } from './NavButton';
 import { HeaderNavItem, HeaderProps } from './types';
 
-/** 상단 공통 헤더: 데스크톱은 로고/네비/유저, 모바일은 햄버거로 토글 */
 const defaultNavItems: HeaderNavItem[] = [
   {
     id: 'law-collection',
@@ -54,9 +53,8 @@ export function Header({
 }: HeaderProps) {
   const navigate = useNavigate();
   const location = useLocation();
-  const [isMobileOpen, setIsMobileOpen] = useState(false); // 모바일 메뉴 토글 상태
+  const [isMobileOpen, setIsMobileOpen] = useState(false);
 
-  // 현재 경로와 일치하는 메뉴 id 찾기
   const isControlled = activeNavId !== undefined;
   const locationMatchedNavId = useMemo(() => {
     return navItems.find(
@@ -76,7 +74,6 @@ export function Header({
     }
   }, [activeNavId, isControlled]);
 
-  // 비제어 모드에서 경로가 변할 때 활성 메뉴를 자동 갱신
   useEffect(() => {
     if (!isControlled) {
       setInternalActiveNavId(locationMatchedNavId ?? undefined);

--- a/src/components/layout/MobileMenu.tsx
+++ b/src/components/layout/MobileMenu.tsx
@@ -17,7 +17,6 @@ interface MobileMenuProps {
   userLabel: string;
 }
 
-/** 모바일 메뉴 드로어 (햄버거 토글 시 표시) */
 export function MobileMenu({
   navItems,
   resolvedActiveNavId,
@@ -39,7 +38,7 @@ export function MobileMenu({
   };
 
   return (
-    <div className="md:hidden border-t border-border-base">
+    <div className="border-t border-border-base md:hidden">
       <div className="mx-auto flex flex-col gap-2 px-4 py-3 sm:px-6">
         <nav className="flex flex-col gap-1.5" aria-label="모바일 내비게이션">
           {navItems.map((item) => {

--- a/src/components/risk/LegalRiskPanel.tsx
+++ b/src/components/risk/LegalRiskPanel.tsx
@@ -63,11 +63,13 @@ export const LegalRiskPanel = () => {
   const { data, error, isLoading, requestLegalRisk } = useLegalRisk();
 
   const canSubmit = useMemo(() => {
+    const age = Number(form.age);
     return (
       form.countryId !== '' &&
       form.travelPurpose !== '' &&
       form.visaType !== '' &&
-      Number(form.age) > 0
+      Number.isFinite(age) &&
+      age > 0
     );
   }, [form]);
 
@@ -113,7 +115,7 @@ export const LegalRiskPanel = () => {
             <option value="3">싱가포르</option>
             <option value="4">독일</option>
             <option value="5">프랑스</option>
-            <option value="6">태국</option>
+            <option value="6">중국</option>
           </DropdownSelect>
 
           <DropdownSelect
@@ -238,27 +240,31 @@ export const LegalRiskPanel = () => {
                   {risk.risk_content}
                 </p>
 
-                <div className="mt-3">
-                  <p className="text-sm font-medium text-text-primary">
-                    권장 조치
-                  </p>
-                  <ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-text-secondary">
-                    {risk.risk_actions.map((action) => (
-                      <li key={action}>{action}</li>
-                    ))}
-                  </ul>
-                </div>
+                {risk.risk_actions.length > 0 ? (
+                  <div className="mt-3">
+                    <p className="text-sm font-medium text-text-primary">
+                      권장 조치
+                    </p>
+                    <ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-text-secondary">
+                      {risk.risk_actions.map((action) => (
+                        <li key={action}>{action}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
 
-                <div className="mt-3 flex flex-wrap gap-2 text-xs text-text-secondary">
-                  {risk.law_refs.map((law) => (
-                    <span
-                      key={`${law.law_id}-${law.article_no}`}
-                      className="rounded-md border border-border-soft px-2 py-1"
-                    >
-                      {law.law_type} {law.article_no}
-                    </span>
-                  ))}
-                </div>
+                {risk.law_refs.length > 0 ? (
+                  <div className="mt-3 flex flex-wrap gap-2 text-xs text-text-secondary">
+                    {risk.law_refs.map((law) => (
+                      <span
+                        key={`${law.law_id}-${law.article_no}`}
+                        className="rounded-md border border-border-soft px-2 py-1"
+                      >
+                        {law.law_type} {law.article_no}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
 
                 {issueRefs.length > 0 ? (
                   <div className="mt-3 space-y-1">

--- a/src/components/risk/LegalRiskPanel.tsx
+++ b/src/components/risk/LegalRiskPanel.tsx
@@ -34,6 +34,15 @@ const riskLevelClassName: Record<RiskLevel, string> = {
 
 const normalizeIssueUrl = (url: string) => url.replace(/^<|>$/g, '');
 
+const isSafeHttpUrl = (url: string) => {
+  try {
+    const parsedUrl = new URL(normalizeIssueUrl(url));
+    return parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
 const getAgeBand = (age: number): AgeBand => {
   if (age < 20) return '10s';
   if (age < 30) return '20s';
@@ -64,6 +73,10 @@ export const LegalRiskPanel = () => {
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+
+    if (isLoading) {
+      return;
+    }
 
     if (!canSubmit) {
       setValidationMessage('체류 정보를 모두 입력해주세요.');
@@ -202,7 +215,9 @@ export const LegalRiskPanel = () => {
           </div>
 
           {data.risk_list.map((risk) => {
-            const issueRefs = risk.issue_refs ?? [];
+            const issueRefs = (risk.issue_refs ?? []).filter((issue) =>
+              isSafeHttpUrl(issue.url),
+            );
 
             return (
               <Card key={risk.risk_title} className="bg-white p-5">

--- a/src/components/risk/LegalRiskPanel.tsx
+++ b/src/components/risk/LegalRiskPanel.tsx
@@ -25,6 +25,8 @@ const riskLevelClassName: Record<RiskLevel, string> = {
   HIGH: 'border-rose-200 bg-rose-50 text-rose-700',
 };
 
+const normalizeIssueUrl = (url: string) => url.replace(/^<|>$/g, '');
+
 export const LegalRiskPanel = () => {
   const [form, setForm] = useState<LegalRiskRequest>({
     country_id: 1,
@@ -157,65 +159,69 @@ export const LegalRiskPanel = () => {
               </span>
             </div>
 
-            {data.risk_list.map((risk) => (
-              <Card key={risk.risk_title} className="p-4">
-                <div className="mb-2 flex flex-wrap items-center gap-2">
-                  <h3 className="text-base font-semibold text-text-primary">
-                    {risk.risk_title}
-                  </h3>
-                  <span
-                    className={`rounded-full border px-2.5 py-0.5 text-xs font-semibold ${
-                      riskLevelClassName[risk.risk_level]
-                    }`}
-                  >
-                    {riskLevelLabel[risk.risk_level]}
-                  </span>
-                </div>
+            {data.risk_list.map((risk) => {
+              const issueRefs = risk.issue_refs ?? [];
 
-                <p className="text-sm leading-6 text-text-secondary">
-                  {risk.risk_content}
-                </p>
-
-                <div className="mt-3">
-                  <p className="text-sm font-medium text-text-primary">
-                    권장 조치
-                  </p>
-                  <ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-text-secondary">
-                    {risk.risk_actions.map((action) => (
-                      <li key={action}>{action}</li>
-                    ))}
-                  </ul>
-                </div>
-
-                <div className="mt-3 flex flex-wrap gap-2 text-xs text-text-secondary">
-                  {risk.law_refs.map((law) => (
+              return (
+                <Card key={risk.risk_title} className="p-4">
+                  <div className="mb-2 flex flex-wrap items-center gap-2">
+                    <h3 className="text-base font-semibold text-text-primary">
+                      {risk.risk_title}
+                    </h3>
                     <span
-                      key={`${law.law_id}-${law.article_no}`}
-                      className="rounded-md border border-border-soft px-2 py-1"
+                      className={`rounded-full border px-2.5 py-0.5 text-xs font-semibold ${
+                        riskLevelClassName[risk.risk_level]
+                      }`}
                     >
-                      {law.law_type} {law.article_no}
+                      {riskLevelLabel[risk.risk_level]}
                     </span>
-                  ))}
-                </div>
+                  </div>
 
-                {risk.issue_refs.length > 0 ? (
-                  <div className="mt-3 space-y-1">
-                    {risk.issue_refs.map((issue) => (
-                      <a
-                        key={issue.issue_id}
-                        href={issue.url}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="flex items-center gap-1 text-sm text-brand-primary hover:underline"
+                  <p className="text-sm leading-6 text-text-secondary">
+                    {risk.risk_content}
+                  </p>
+
+                  <div className="mt-3">
+                    <p className="text-sm font-medium text-text-primary">
+                      권장 조치
+                    </p>
+                    <ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-text-secondary">
+                      {risk.risk_actions.map((action) => (
+                        <li key={action}>{action}</li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  <div className="mt-3 flex flex-wrap gap-2 text-xs text-text-secondary">
+                    {risk.law_refs.map((law) => (
+                      <span
+                        key={`${law.law_id}-${law.article_no}`}
+                        className="rounded-md border border-border-soft px-2 py-1"
                       >
-                        {issue.title}
-                        <ExternalLink className="h-3.5 w-3.5" />
-                      </a>
+                        {law.law_type} {law.article_no}
+                      </span>
                     ))}
                   </div>
-                ) : null}
-              </Card>
-            ))}
+
+                  {issueRefs.length > 0 ? (
+                    <div className="mt-3 space-y-1">
+                      {issueRefs.map((issue) => (
+                        <a
+                          key={issue.issue_id}
+                          href={normalizeIssueUrl(issue.url)}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="flex items-center gap-1 text-sm text-brand-primary hover:underline"
+                        >
+                          {issue.title}
+                          <ExternalLink className="h-3.5 w-3.5" />
+                        </a>
+                      ))}
+                    </div>
+                  ) : null}
+                </Card>
+              );
+            })}
           </div>
         ) : null}
       </div>

--- a/src/components/risk/LegalRiskPanel.tsx
+++ b/src/components/risk/LegalRiskPanel.tsx
@@ -1,0 +1,224 @@
+import { FormEvent, useState } from 'react';
+import { AlertTriangle, ExternalLink, ShieldCheck } from 'lucide-react';
+import { Button } from '@/components/common/button/Button';
+import { Card } from '@/components/common/Card';
+import { DropdownSelect } from '@/components/common/dropdown/DropdownSelect';
+import { Input } from '@/components/common/input/Input';
+import { useLegalRisk } from '@/hooks/useLegalRisk';
+import type {
+  AgeBand,
+  LegalRiskRequest,
+  RiskLevel,
+  TravelPurpose,
+  VisaType,
+} from '@/types/legalRisk';
+
+const riskLevelLabel: Record<RiskLevel, string> = {
+  LOW: '낮음',
+  MEDIUM: '보통',
+  HIGH: '높음',
+};
+
+const riskLevelClassName: Record<RiskLevel, string> = {
+  LOW: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  MEDIUM: 'border-amber-200 bg-amber-50 text-amber-700',
+  HIGH: 'border-rose-200 bg-rose-50 text-rose-700',
+};
+
+export const LegalRiskPanel = () => {
+  const [form, setForm] = useState<LegalRiskRequest>({
+    country_id: 1,
+    travel_purpose: 'tourism',
+    visa_type: 'short_stay',
+    age_band: '20s',
+  });
+  const { data, error, isLoading, requestLegalRisk } = useLegalRisk();
+
+  const updateForm = <K extends keyof LegalRiskRequest>(
+    key: K,
+    value: LegalRiskRequest[K],
+  ) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    void requestLegalRisk(form);
+  };
+
+  return (
+    <section className="border-b border-gray-200 bg-white">
+      <div className="mx-auto max-w-4xl px-4 py-5 sm:px-6 lg:px-8">
+        <div className="mb-4 flex items-center gap-3">
+          <div className="rounded-md bg-brand-light p-2 text-brand-primary">
+            <ShieldCheck className="h-5 w-5" />
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold text-text-primary">
+              여행 법률 리스크 조회
+            </h2>
+            <p className="text-sm text-text-secondary">
+              국가, 방문 목적, 비자, 연령대를 기준으로 주요 리스크를 확인합니다.
+            </p>
+          </div>
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className="grid gap-3 md:grid-cols-[1fr_1fr_1fr_1fr_auto]"
+        >
+          <div className="flex w-full flex-col gap-2">
+            <label
+              htmlFor="legal-risk-country"
+              className="text-sm font-medium text-text-primary"
+            >
+              국가 ID
+            </label>
+            <Input
+              id="legal-risk-country"
+              type="number"
+              min={1}
+              value={form.country_id}
+              onChange={(event) =>
+                updateForm('country_id', Number(event.target.value))
+              }
+              className="h-10"
+            />
+          </div>
+
+          <DropdownSelect
+            label="방문 목적"
+            value={form.travel_purpose}
+            onChange={(event) =>
+              updateForm('travel_purpose', event.target.value as TravelPurpose)
+            }
+          >
+            <option value="tourism">관광</option>
+            <option value="business">비즈니스</option>
+            <option value="study">유학</option>
+            <option value="work">취업</option>
+            <option value="other">기타</option>
+          </DropdownSelect>
+
+          <DropdownSelect
+            label="비자 유형"
+            value={form.visa_type}
+            onChange={(event) =>
+              updateForm('visa_type', event.target.value as VisaType)
+            }
+          >
+            <option value="short_stay">단기 체류</option>
+            <option value="long_stay">장기 체류</option>
+            <option value="visa_free">무비자</option>
+            <option value="student">학생 비자</option>
+            <option value="work">취업 비자</option>
+            <option value="other">기타</option>
+          </DropdownSelect>
+
+          <DropdownSelect
+            label="연령대"
+            value={form.age_band}
+            onChange={(event) =>
+              updateForm('age_band', event.target.value as AgeBand)
+            }
+          >
+            <option value="10s">10대</option>
+            <option value="20s">20대</option>
+            <option value="30s">30대</option>
+            <option value="40s">40대</option>
+            <option value="50s">50대</option>
+            <option value="60s_plus">60대 이상</option>
+          </DropdownSelect>
+
+          <Button type="submit" disabled={isLoading} className="self-end">
+            {isLoading ? '조회 중' : '조회'}
+          </Button>
+        </form>
+
+        {error ? (
+          <div className="mt-4 flex items-start gap-2 rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>{error.message}</span>
+          </div>
+        ) : null}
+
+        {data ? (
+          <div className="mt-5 space-y-3">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-text-secondary">
+                종합 리스크
+              </span>
+              <span
+                className={`rounded-full border px-3 py-1 text-xs font-semibold ${
+                  riskLevelClassName[data.overall_risk_level]
+                }`}
+              >
+                {riskLevelLabel[data.overall_risk_level]}
+              </span>
+            </div>
+
+            {data.risk_list.map((risk) => (
+              <Card key={risk.risk_title} className="p-4">
+                <div className="mb-2 flex flex-wrap items-center gap-2">
+                  <h3 className="text-base font-semibold text-text-primary">
+                    {risk.risk_title}
+                  </h3>
+                  <span
+                    className={`rounded-full border px-2.5 py-0.5 text-xs font-semibold ${
+                      riskLevelClassName[risk.risk_level]
+                    }`}
+                  >
+                    {riskLevelLabel[risk.risk_level]}
+                  </span>
+                </div>
+
+                <p className="text-sm leading-6 text-text-secondary">
+                  {risk.risk_content}
+                </p>
+
+                <div className="mt-3">
+                  <p className="text-sm font-medium text-text-primary">
+                    권장 조치
+                  </p>
+                  <ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-text-secondary">
+                    {risk.risk_actions.map((action) => (
+                      <li key={action}>{action}</li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div className="mt-3 flex flex-wrap gap-2 text-xs text-text-secondary">
+                  {risk.law_refs.map((law) => (
+                    <span
+                      key={`${law.law_id}-${law.article_no}`}
+                      className="rounded-md border border-border-soft px-2 py-1"
+                    >
+                      {law.law_type} {law.article_no}
+                    </span>
+                  ))}
+                </div>
+
+                {risk.issue_refs.length > 0 ? (
+                  <div className="mt-3 space-y-1">
+                    {risk.issue_refs.map((issue) => (
+                      <a
+                        key={issue.issue_id}
+                        href={issue.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="flex items-center gap-1 text-sm text-brand-primary hover:underline"
+                      >
+                        {issue.title}
+                        <ExternalLink className="h-3.5 w-3.5" />
+                      </a>
+                    ))}
+                  </div>
+                ) : null}
+              </Card>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+};

--- a/src/components/risk/LegalRiskPanel.tsx
+++ b/src/components/risk/LegalRiskPanel.tsx
@@ -32,6 +32,22 @@ const riskLevelClassName: Record<RiskLevel, string> = {
   HIGH: 'border-rose-200 bg-rose-50 text-rose-700',
 };
 
+const countries = [
+  { id: 1, label: '미국 (연방)' },
+  { id: 2, label: '미국 - 캘리포니아' },
+  { id: 3, label: '미국 - 뉴욕' },
+  { id: 4, label: '캐나다 (연방)' },
+  { id: 5, label: '캐나다 - 온타리오' },
+  { id: 6, label: '캐나다 - 브리티시컬럼비아' },
+  { id: 7, label: '호주 (연방)' },
+  { id: 8, label: '호주 - 뉴사우스웨일스' },
+  { id: 9, label: '호주 - 퀸즐랜드' },
+  { id: 10, label: '호주 - 서호주' },
+  { id: 11, label: '호주 - 남호주' },
+  { id: 12, label: '호주 - 태즈메이니아' },
+  { id: 13, label: '호주 - 노퍽 섬' },
+];
+
 const normalizeIssueUrl = (url: string) => url.replace(/^<|>$/g, '');
 
 const isSafeHttpUrl = (url: string) => {
@@ -48,8 +64,7 @@ const getAgeBand = (age: number): AgeBand => {
   if (age < 30) return '20s';
   if (age < 40) return '30s';
   if (age < 50) return '40s';
-  if (age < 60) return '50s';
-  return '60s_plus';
+  return '50s_plus';
 };
 
 export const LegalRiskPanel = () => {
@@ -110,12 +125,11 @@ export const LegalRiskPanel = () => {
             className="h-10 bg-gray-50"
           >
             <option value="">체류국가를 선택하세요</option>
-            <option value="1">미국</option>
-            <option value="2">일본</option>
-            <option value="3">싱가포르</option>
-            <option value="4">독일</option>
-            <option value="5">프랑스</option>
-            <option value="6">중국</option>
+            {countries.map((country) => (
+              <option key={country.id} value={country.id}>
+                {country.label}
+              </option>
+            ))}
           </DropdownSelect>
 
           <DropdownSelect
@@ -131,14 +145,14 @@ export const LegalRiskPanel = () => {
           >
             <option value="">체류목적을 선택하세요</option>
             <option value="tourism">관광</option>
-            <option value="business">비즈니스</option>
+            <option value="business">출장/비즈니스</option>
             <option value="study">유학</option>
             <option value="work">취업</option>
-            <option value="other">기타</option>
+            <option value="working_holiday">워킹홀리데이</option>
           </DropdownSelect>
 
           <DropdownSelect
-            label="비자 종류"
+            label="비자 유형"
             value={form.visaType}
             onChange={(event) =>
               setForm((prev) => ({
@@ -148,13 +162,11 @@ export const LegalRiskPanel = () => {
             }
             className="h-10 bg-gray-50"
           >
-            <option value="">비자 종류를 선택하세요</option>
+            <option value="">비자 유형을 선택하세요</option>
             <option value="short_stay">단기 체류</option>
             <option value="long_stay">장기 체류</option>
-            <option value="visa_free">무비자</option>
-            <option value="student">학생 비자</option>
-            <option value="work">취업 비자</option>
-            <option value="other">기타</option>
+            <option value="work_permit">취업 허가</option>
+            <option value="student_visa">학생 비자</option>
           </DropdownSelect>
 
           <div className="flex w-full flex-col gap-2">

--- a/src/components/risk/LegalRiskPanel.tsx
+++ b/src/components/risk/LegalRiskPanel.tsx
@@ -1,5 +1,5 @@
-import { FormEvent, useState } from 'react';
-import { AlertTriangle, ExternalLink, ShieldCheck } from 'lucide-react';
+import { FormEvent, useMemo, useState } from 'react';
+import { AlertTriangle, ExternalLink } from 'lucide-react';
 import { Button } from '@/components/common/button/Button';
 import { Card } from '@/components/common/Card';
 import { DropdownSelect } from '@/components/common/dropdown/DropdownSelect';
@@ -12,6 +12,13 @@ import type {
   TravelPurpose,
   VisaType,
 } from '@/types/legalRisk';
+
+type RiskFormState = {
+  countryId: string;
+  travelPurpose: '' | TravelPurpose;
+  visaType: '' | VisaType;
+  age: string;
+};
 
 const riskLevelLabel: Record<RiskLevel, string> = {
   LOW: '낮음',
@@ -27,74 +34,87 @@ const riskLevelClassName: Record<RiskLevel, string> = {
 
 const normalizeIssueUrl = (url: string) => url.replace(/^<|>$/g, '');
 
+const getAgeBand = (age: number): AgeBand => {
+  if (age < 20) return '10s';
+  if (age < 30) return '20s';
+  if (age < 40) return '30s';
+  if (age < 50) return '40s';
+  if (age < 60) return '50s';
+  return '60s_plus';
+};
+
 export const LegalRiskPanel = () => {
-  const [form, setForm] = useState<LegalRiskRequest>({
-    country_id: 1,
-    travel_purpose: 'tourism',
-    visa_type: 'short_stay',
-    age_band: '20s',
+  const [form, setForm] = useState<RiskFormState>({
+    countryId: '',
+    travelPurpose: '',
+    visaType: '',
+    age: '',
   });
+  const [validationMessage, setValidationMessage] = useState('');
   const { data, error, isLoading, requestLegalRisk } = useLegalRisk();
 
-  const updateForm = <K extends keyof LegalRiskRequest>(
-    key: K,
-    value: LegalRiskRequest[K],
-  ) => {
-    setForm((prev) => ({ ...prev, [key]: value }));
-  };
+  const canSubmit = useMemo(() => {
+    return (
+      form.countryId !== '' &&
+      form.travelPurpose !== '' &&
+      form.visaType !== '' &&
+      Number(form.age) > 0
+    );
+  }, [form]);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    void requestLegalRisk(form);
+
+    if (!canSubmit) {
+      setValidationMessage('체류 정보를 모두 입력해주세요.');
+      return;
+    }
+
+    setValidationMessage('');
+
+    const payload: LegalRiskRequest = {
+      country_id: Number(form.countryId),
+      travel_purpose: form.travelPurpose as TravelPurpose,
+      visa_type: form.visaType as VisaType,
+      age_band: getAgeBand(Number(form.age)),
+    };
+
+    void requestLegalRisk(payload);
   };
 
   return (
-    <section className="border-b border-gray-200 bg-white">
-      <div className="mx-auto max-w-4xl px-4 py-5 sm:px-6 lg:px-8">
-        <div className="mb-4 flex items-center gap-3">
-          <div className="rounded-md bg-brand-light p-2 text-brand-primary">
-            <ShieldCheck className="h-5 w-5" />
-          </div>
-          <div>
-            <h2 className="text-lg font-semibold text-text-primary">
-              여행 법률 리스크 조회
-            </h2>
-            <p className="text-sm text-text-secondary">
-              국가, 방문 목적, 비자, 연령대를 기준으로 주요 리스크를 확인합니다.
-            </p>
-          </div>
-        </div>
-
-        <form
-          onSubmit={handleSubmit}
-          className="grid gap-3 md:grid-cols-[1fr_1fr_1fr_1fr_auto]"
-        >
-          <div className="flex w-full flex-col gap-2">
-            <label
-              htmlFor="legal-risk-country"
-              className="text-sm font-medium text-text-primary"
-            >
-              국가 ID
-            </label>
-            <Input
-              id="legal-risk-country"
-              type="number"
-              min={1}
-              value={form.country_id}
-              onChange={(event) =>
-                updateForm('country_id', Number(event.target.value))
-              }
-              className="h-10"
-            />
-          </div>
+    <div className="mx-auto max-w-[1280px]">
+      <Card className="rounded-lg border-border-soft bg-white p-7 shadow-sm">
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <DropdownSelect
+            label="체류국가"
+            value={form.countryId}
+            onChange={(event) =>
+              setForm((prev) => ({ ...prev, countryId: event.target.value }))
+            }
+            className="h-10 bg-gray-50"
+          >
+            <option value="">체류국가를 선택하세요</option>
+            <option value="1">미국</option>
+            <option value="2">일본</option>
+            <option value="3">싱가포르</option>
+            <option value="4">독일</option>
+            <option value="5">프랑스</option>
+            <option value="6">태국</option>
+          </DropdownSelect>
 
           <DropdownSelect
-            label="방문 목적"
-            value={form.travel_purpose}
+            label="체류목적"
+            value={form.travelPurpose}
             onChange={(event) =>
-              updateForm('travel_purpose', event.target.value as TravelPurpose)
+              setForm((prev) => ({
+                ...prev,
+                travelPurpose: event.target.value as TravelPurpose,
+              }))
             }
+            className="h-10 bg-gray-50"
           >
+            <option value="">체류목적을 선택하세요</option>
             <option value="tourism">관광</option>
             <option value="business">비즈니스</option>
             <option value="study">유학</option>
@@ -103,12 +123,17 @@ export const LegalRiskPanel = () => {
           </DropdownSelect>
 
           <DropdownSelect
-            label="비자 유형"
-            value={form.visa_type}
+            label="비자 종류"
+            value={form.visaType}
             onChange={(event) =>
-              updateForm('visa_type', event.target.value as VisaType)
+              setForm((prev) => ({
+                ...prev,
+                visaType: event.target.value as VisaType,
+              }))
             }
+            className="h-10 bg-gray-50"
           >
+            <option value="">비자 종류를 선택하세요</option>
             <option value="short_stay">단기 체류</option>
             <option value="long_stay">장기 체류</option>
             <option value="visa_free">무비자</option>
@@ -117,25 +142,41 @@ export const LegalRiskPanel = () => {
             <option value="other">기타</option>
           </DropdownSelect>
 
-          <DropdownSelect
-            label="연령대"
-            value={form.age_band}
-            onChange={(event) =>
-              updateForm('age_band', event.target.value as AgeBand)
-            }
-          >
-            <option value="10s">10대</option>
-            <option value="20s">20대</option>
-            <option value="30s">30대</option>
-            <option value="40s">40대</option>
-            <option value="50s">50대</option>
-            <option value="60s_plus">60대 이상</option>
-          </DropdownSelect>
+          <div className="flex w-full flex-col gap-2">
+            <label
+              htmlFor="risk-age"
+              className="text-sm font-medium text-text-primary"
+            >
+              연령
+            </label>
+            <Input
+              id="risk-age"
+              type="number"
+              min={1}
+              placeholder="연령을 입력하세요"
+              value={form.age}
+              onChange={(event) =>
+                setForm((prev) => ({ ...prev, age: event.target.value }))
+              }
+              className="h-11 bg-gray-50"
+            />
+          </div>
 
-          <Button type="submit" disabled={isLoading} className="self-end">
-            {isLoading ? '조회 중' : '조회'}
+          <Button
+            type="submit"
+            disabled={isLoading}
+            className="h-11 w-full gap-2 bg-[#9ea4f3] text-base hover:bg-[#8f96ee]"
+          >
+            <AlertTriangle className="h-4 w-4" />
+            {isLoading ? '위험 지수 분석 중' : '위험 지수 분석하기'}
           </Button>
         </form>
+
+        {validationMessage ? (
+          <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
+            {validationMessage}
+          </div>
+        ) : null}
 
         {error ? (
           <div className="mt-4 flex items-start gap-2 rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
@@ -143,88 +184,88 @@ export const LegalRiskPanel = () => {
             <span>{error.message}</span>
           </div>
         ) : null}
+      </Card>
 
-        {data ? (
-          <div className="mt-5 space-y-3">
-            <div className="flex items-center gap-2">
-              <span className="text-sm font-medium text-text-secondary">
-                종합 리스크
-              </span>
-              <span
-                className={`rounded-full border px-3 py-1 text-xs font-semibold ${
-                  riskLevelClassName[data.overall_risk_level]
-                }`}
-              >
-                {riskLevelLabel[data.overall_risk_level]}
-              </span>
-            </div>
+      {data ? (
+        <div className="mt-6 space-y-4">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-text-secondary">
+              종합 위험 지수
+            </span>
+            <span
+              className={`rounded-full border px-3 py-1 text-xs font-semibold ${
+                riskLevelClassName[data.overall_risk_level]
+              }`}
+            >
+              {riskLevelLabel[data.overall_risk_level]}
+            </span>
+          </div>
 
-            {data.risk_list.map((risk) => {
-              const issueRefs = risk.issue_refs ?? [];
+          {data.risk_list.map((risk) => {
+            const issueRefs = risk.issue_refs ?? [];
 
-              return (
-                <Card key={risk.risk_title} className="p-4">
-                  <div className="mb-2 flex flex-wrap items-center gap-2">
-                    <h3 className="text-base font-semibold text-text-primary">
-                      {risk.risk_title}
-                    </h3>
-                    <span
-                      className={`rounded-full border px-2.5 py-0.5 text-xs font-semibold ${
-                        riskLevelClassName[risk.risk_level]
-                      }`}
-                    >
-                      {riskLevelLabel[risk.risk_level]}
-                    </span>
-                  </div>
+            return (
+              <Card key={risk.risk_title} className="bg-white p-5">
+                <div className="mb-2 flex flex-wrap items-center gap-2">
+                  <h3 className="text-base font-semibold text-text-primary">
+                    {risk.risk_title}
+                  </h3>
+                  <span
+                    className={`rounded-full border px-2.5 py-0.5 text-xs font-semibold ${
+                      riskLevelClassName[risk.risk_level]
+                    }`}
+                  >
+                    {riskLevelLabel[risk.risk_level]}
+                  </span>
+                </div>
 
-                  <p className="text-sm leading-6 text-text-secondary">
-                    {risk.risk_content}
+                <p className="text-sm leading-6 text-text-secondary">
+                  {risk.risk_content}
+                </p>
+
+                <div className="mt-3">
+                  <p className="text-sm font-medium text-text-primary">
+                    권장 조치
                   </p>
+                  <ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-text-secondary">
+                    {risk.risk_actions.map((action) => (
+                      <li key={action}>{action}</li>
+                    ))}
+                  </ul>
+                </div>
 
-                  <div className="mt-3">
-                    <p className="text-sm font-medium text-text-primary">
-                      권장 조치
-                    </p>
-                    <ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-text-secondary">
-                      {risk.risk_actions.map((action) => (
-                        <li key={action}>{action}</li>
-                      ))}
-                    </ul>
-                  </div>
+                <div className="mt-3 flex flex-wrap gap-2 text-xs text-text-secondary">
+                  {risk.law_refs.map((law) => (
+                    <span
+                      key={`${law.law_id}-${law.article_no}`}
+                      className="rounded-md border border-border-soft px-2 py-1"
+                    >
+                      {law.law_type} {law.article_no}
+                    </span>
+                  ))}
+                </div>
 
-                  <div className="mt-3 flex flex-wrap gap-2 text-xs text-text-secondary">
-                    {risk.law_refs.map((law) => (
-                      <span
-                        key={`${law.law_id}-${law.article_no}`}
-                        className="rounded-md border border-border-soft px-2 py-1"
+                {issueRefs.length > 0 ? (
+                  <div className="mt-3 space-y-1">
+                    {issueRefs.map((issue) => (
+                      <a
+                        key={issue.issue_id}
+                        href={normalizeIssueUrl(issue.url)}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="flex items-center gap-1 text-sm text-brand-primary hover:underline"
                       >
-                        {law.law_type} {law.article_no}
-                      </span>
+                        {issue.title}
+                        <ExternalLink className="h-3.5 w-3.5" />
+                      </a>
                     ))}
                   </div>
-
-                  {issueRefs.length > 0 ? (
-                    <div className="mt-3 space-y-1">
-                      {issueRefs.map((issue) => (
-                        <a
-                          key={issue.issue_id}
-                          href={normalizeIssueUrl(issue.url)}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="flex items-center gap-1 text-sm text-brand-primary hover:underline"
-                        >
-                          {issue.title}
-                          <ExternalLink className="h-3.5 w-3.5" />
-                        </a>
-                      ))}
-                    </div>
-                  ) : null}
-                </Card>
-              );
-            })}
-          </div>
-        ) : null}
-      </div>
-    </section>
+                ) : null}
+              </Card>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
   );
 };

--- a/src/components/risk/LegalRiskPanel.tsx
+++ b/src/components/risk/LegalRiskPanel.tsx
@@ -19,7 +19,7 @@ type RiskFormState = {
   ageBand: '' | AgeBand;
 };
 
-const countries = [
+const countryOptions = [
   { id: 1, label: '미국 (연방)' },
   { id: 2, label: '미국 - 캘리포니아' },
   { id: 3, label: '미국 - 뉴욕' },
@@ -35,7 +35,22 @@ const countries = [
   { id: 13, label: '호주 - 노퍽 섬' },
 ];
 
-const ageBands: Array<{ value: AgeBand; label: string }> = [
+const travelPurposeOptions: Array<{ value: TravelPurpose; label: string }> = [
+  { value: 'tourism', label: '관광' },
+  { value: 'business', label: '출장/비즈니스' },
+  { value: 'study', label: '유학' },
+  { value: 'work', label: '취업' },
+  { value: 'working_holiday', label: '워킹홀리데이' },
+];
+
+const visaTypeOptions: Array<{ value: VisaType; label: string }> = [
+  { value: 'short_stay', label: '단기 체류' },
+  { value: 'long_stay', label: '장기 체류' },
+  { value: 'work_permit', label: '취업 허가' },
+  { value: 'student_visa', label: '학생 비자' },
+];
+
+const ageBandOptions: Array<{ value: AgeBand; label: string }> = [
   { value: '10s', label: '10대' },
   { value: '20s', label: '20대' },
   { value: '30s', label: '30대' },
@@ -71,7 +86,7 @@ export const LegalRiskPanel = () => {
     }
 
     if (!canSubmit) {
-      setValidationMessage('체류 정보를 모두 입력해주세요.');
+      setValidationMessage('체류 정보를 모두 선택해주세요.');
       return;
     }
 
@@ -103,7 +118,7 @@ export const LegalRiskPanel = () => {
             className="h-10 bg-gray-50"
           >
             <option value="">체류국가를 선택하세요</option>
-            {countries.map((country) => (
+            {countryOptions.map((country) => (
               <option key={country.id} value={country.id}>
                 {country.label}
               </option>
@@ -122,11 +137,11 @@ export const LegalRiskPanel = () => {
             className="h-10 bg-gray-50"
           >
             <option value="">체류목적을 선택하세요</option>
-            <option value="tourism">관광</option>
-            <option value="business">출장/비즈니스</option>
-            <option value="study">유학</option>
-            <option value="work">취업</option>
-            <option value="working_holiday">워킹홀리데이</option>
+            {travelPurposeOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
           </DropdownSelect>
 
           <DropdownSelect
@@ -141,10 +156,11 @@ export const LegalRiskPanel = () => {
             className="h-10 bg-gray-50"
           >
             <option value="">비자 유형을 선택하세요</option>
-            <option value="short_stay">단기 체류</option>
-            <option value="long_stay">장기 체류</option>
-            <option value="work_permit">취업 허가</option>
-            <option value="student_visa">학생 비자</option>
+            {visaTypeOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
           </DropdownSelect>
 
           <DropdownSelect
@@ -159,7 +175,7 @@ export const LegalRiskPanel = () => {
             className="h-10 bg-gray-50"
           >
             <option value="">연령대를 선택하세요</option>
-            {ageBands.map((ageBand) => (
+            {ageBandOptions.map((ageBand) => (
               <option key={ageBand.value} value={ageBand.value}>
                 {ageBand.label}
               </option>

--- a/src/components/risk/LegalRiskPanel.tsx
+++ b/src/components/risk/LegalRiskPanel.tsx
@@ -1,14 +1,13 @@
 import { FormEvent, useMemo, useState } from 'react';
-import { AlertTriangle, ExternalLink } from 'lucide-react';
+import { AlertTriangle } from 'lucide-react';
 import { Button } from '@/components/common/button/Button';
 import { Card } from '@/components/common/Card';
 import { DropdownSelect } from '@/components/common/dropdown/DropdownSelect';
-import { Input } from '@/components/common/input/Input';
+import { LegalRiskResultModal } from '@/components/risk/LegalRiskResultModal';
 import { useLegalRisk } from '@/hooks/useLegalRisk';
 import type {
   AgeBand,
   LegalRiskRequest,
-  RiskLevel,
   TravelPurpose,
   VisaType,
 } from '@/types/legalRisk';
@@ -17,19 +16,7 @@ type RiskFormState = {
   countryId: string;
   travelPurpose: '' | TravelPurpose;
   visaType: '' | VisaType;
-  age: string;
-};
-
-const riskLevelLabel: Record<RiskLevel, string> = {
-  LOW: '낮음',
-  MEDIUM: '보통',
-  HIGH: '높음',
-};
-
-const riskLevelClassName: Record<RiskLevel, string> = {
-  LOW: 'border-emerald-200 bg-emerald-50 text-emerald-700',
-  MEDIUM: 'border-amber-200 bg-amber-50 text-amber-700',
-  HIGH: 'border-rose-200 bg-rose-50 text-rose-700',
+  ageBand: '' | AgeBand;
 };
 
 const countries = [
@@ -48,47 +35,35 @@ const countries = [
   { id: 13, label: '호주 - 노퍽 섬' },
 ];
 
-const normalizeIssueUrl = (url: string) => url.replace(/^<|>$/g, '');
-
-const isSafeHttpUrl = (url: string) => {
-  try {
-    const parsedUrl = new URL(normalizeIssueUrl(url));
-    return parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:';
-  } catch {
-    return false;
-  }
-};
-
-const getAgeBand = (age: number): AgeBand => {
-  if (age < 20) return '10s';
-  if (age < 30) return '20s';
-  if (age < 40) return '30s';
-  if (age < 50) return '40s';
-  return '50s_plus';
-};
+const ageBands: Array<{ value: AgeBand; label: string }> = [
+  { value: '10s', label: '10대' },
+  { value: '20s', label: '20대' },
+  { value: '30s', label: '30대' },
+  { value: '40s', label: '40대' },
+  { value: '50s_plus', label: '50대 이상' },
+];
 
 export const LegalRiskPanel = () => {
   const [form, setForm] = useState<RiskFormState>({
     countryId: '',
     travelPurpose: '',
     visaType: '',
-    age: '',
+    ageBand: '',
   });
   const [validationMessage, setValidationMessage] = useState('');
+  const [isResultOpen, setIsResultOpen] = useState(false);
   const { data, error, isLoading, requestLegalRisk } = useLegalRisk();
 
   const canSubmit = useMemo(() => {
-    const age = Number(form.age);
     return (
       form.countryId !== '' &&
       form.travelPurpose !== '' &&
       form.visaType !== '' &&
-      Number.isFinite(age) &&
-      age > 0
+      form.ageBand !== ''
     );
   }, [form]);
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
     if (isLoading) {
@@ -106,10 +81,13 @@ export const LegalRiskPanel = () => {
       country_id: Number(form.countryId),
       travel_purpose: form.travelPurpose as TravelPurpose,
       visa_type: form.visaType as VisaType,
-      age_band: getAgeBand(Number(form.age)),
+      age_band: form.ageBand as AgeBand,
     };
 
-    void requestLegalRisk(payload);
+    const result = await requestLegalRisk(payload);
+    if (result) {
+      setIsResultOpen(true);
+    }
   };
 
   return (
@@ -169,25 +147,24 @@ export const LegalRiskPanel = () => {
             <option value="student_visa">학생 비자</option>
           </DropdownSelect>
 
-          <div className="flex w-full flex-col gap-2">
-            <label
-              htmlFor="risk-age"
-              className="text-sm font-medium text-text-primary"
-            >
-              연령
-            </label>
-            <Input
-              id="risk-age"
-              type="number"
-              min={1}
-              placeholder="연령을 입력하세요"
-              value={form.age}
-              onChange={(event) =>
-                setForm((prev) => ({ ...prev, age: event.target.value }))
-              }
-              className="h-11 bg-gray-50"
-            />
-          </div>
+          <DropdownSelect
+            label="연령대"
+            value={form.ageBand}
+            onChange={(event) =>
+              setForm((prev) => ({
+                ...prev,
+                ageBand: event.target.value as AgeBand,
+              }))
+            }
+            className="h-10 bg-gray-50"
+          >
+            <option value="">연령대를 선택하세요</option>
+            {ageBands.map((ageBand) => (
+              <option key={ageBand.value} value={ageBand.value}>
+                {ageBand.label}
+              </option>
+            ))}
+          </DropdownSelect>
 
           <Button
             type="submit"
@@ -213,92 +190,11 @@ export const LegalRiskPanel = () => {
         ) : null}
       </Card>
 
-      {data ? (
-        <div className="mt-6 space-y-4">
-          <div className="flex items-center gap-2">
-            <span className="text-sm font-medium text-text-secondary">
-              종합 위험 지수
-            </span>
-            <span
-              className={`rounded-full border px-3 py-1 text-xs font-semibold ${
-                riskLevelClassName[data.overall_risk_level]
-              }`}
-            >
-              {riskLevelLabel[data.overall_risk_level]}
-            </span>
-          </div>
-
-          {data.risk_list.map((risk) => {
-            const issueRefs = (risk.issue_refs ?? []).filter((issue) =>
-              isSafeHttpUrl(issue.url),
-            );
-
-            return (
-              <Card key={risk.risk_title} className="bg-white p-5">
-                <div className="mb-2 flex flex-wrap items-center gap-2">
-                  <h3 className="text-base font-semibold text-text-primary">
-                    {risk.risk_title}
-                  </h3>
-                  <span
-                    className={`rounded-full border px-2.5 py-0.5 text-xs font-semibold ${
-                      riskLevelClassName[risk.risk_level]
-                    }`}
-                  >
-                    {riskLevelLabel[risk.risk_level]}
-                  </span>
-                </div>
-
-                <p className="text-sm leading-6 text-text-secondary">
-                  {risk.risk_content}
-                </p>
-
-                {risk.risk_actions.length > 0 ? (
-                  <div className="mt-3">
-                    <p className="text-sm font-medium text-text-primary">
-                      권장 조치
-                    </p>
-                    <ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-text-secondary">
-                      {risk.risk_actions.map((action) => (
-                        <li key={action}>{action}</li>
-                      ))}
-                    </ul>
-                  </div>
-                ) : null}
-
-                {risk.law_refs.length > 0 ? (
-                  <div className="mt-3 flex flex-wrap gap-2 text-xs text-text-secondary">
-                    {risk.law_refs.map((law) => (
-                      <span
-                        key={`${law.law_id}-${law.article_no}`}
-                        className="rounded-md border border-border-soft px-2 py-1"
-                      >
-                        {law.law_type} {law.article_no}
-                      </span>
-                    ))}
-                  </div>
-                ) : null}
-
-                {issueRefs.length > 0 ? (
-                  <div className="mt-3 space-y-1">
-                    {issueRefs.map((issue) => (
-                      <a
-                        key={issue.issue_id}
-                        href={normalizeIssueUrl(issue.url)}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="flex items-center gap-1 text-sm text-brand-primary hover:underline"
-                      >
-                        {issue.title}
-                        <ExternalLink className="h-3.5 w-3.5" />
-                      </a>
-                    ))}
-                  </div>
-                ) : null}
-              </Card>
-            );
-          })}
-        </div>
-      ) : null}
+      <LegalRiskResultModal
+        open={isResultOpen}
+        onClose={() => setIsResultOpen(false)}
+        result={data}
+      />
     </div>
   );
 };

--- a/src/components/risk/LegalRiskResultModal.tsx
+++ b/src/components/risk/LegalRiskResultModal.tsx
@@ -1,0 +1,144 @@
+import { ExternalLink } from 'lucide-react';
+import { Modal } from '@/components/common/Modal';
+import type { LegalRiskResult, RiskLevel } from '@/types/legalRisk';
+
+type LegalRiskResultModalProps = {
+  open: boolean;
+  onClose: () => void;
+  result: LegalRiskResult | null;
+};
+
+const riskLevelLabel: Record<RiskLevel, string> = {
+  LOW: '낮음',
+  MEDIUM: '보통',
+  HIGH: '높음',
+};
+
+const riskLevelClassName: Record<RiskLevel, string> = {
+  LOW: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  MEDIUM: 'border-amber-200 bg-amber-50 text-amber-700',
+  HIGH: 'border-rose-200 bg-rose-50 text-rose-700',
+};
+
+const normalizeIssueUrl = (url: string) => url.replace(/^<|>$/g, '');
+
+const isSafeHttpUrl = (url: string) => {
+  try {
+    const parsedUrl = new URL(normalizeIssueUrl(url));
+    return parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+export const LegalRiskResultModal = ({
+  open,
+  onClose,
+  result,
+}: LegalRiskResultModalProps) => {
+  if (!result) {
+    return null;
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title="위험 지수 분석 결과"
+      description="입력하신 체류 조건 기준으로 확인된 주요 법률 리스크입니다."
+      widthClass="max-w-[760px]"
+    >
+      <div className="space-y-5">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-text-secondary">
+            종합 위험 지수
+          </span>
+          <span
+            className={`rounded-full border px-3 py-1 text-xs font-semibold ${
+              riskLevelClassName[result.overall_risk_level]
+            }`}
+          >
+            {riskLevelLabel[result.overall_risk_level]}
+          </span>
+        </div>
+
+        <div className="space-y-4">
+          {result.risk_list.map((risk) => {
+            const issueRefs = (risk.issue_refs ?? []).filter((issue) =>
+              isSafeHttpUrl(issue.url),
+            );
+
+            return (
+              <section
+                key={risk.risk_title}
+                className="rounded-lg border border-border-soft bg-white p-4"
+              >
+                <div className="mb-2 flex flex-wrap items-center gap-2">
+                  <h3 className="text-base font-semibold text-text-primary">
+                    {risk.risk_title}
+                  </h3>
+                  <span
+                    className={`rounded-full border px-2.5 py-0.5 text-xs font-semibold ${
+                      riskLevelClassName[risk.risk_level]
+                    }`}
+                  >
+                    {riskLevelLabel[risk.risk_level]}
+                  </span>
+                </div>
+
+                <p className="text-sm leading-6 text-text-secondary">
+                  {risk.risk_content}
+                </p>
+
+                {risk.risk_actions.length > 0 ? (
+                  <div className="mt-3">
+                    <p className="text-sm font-medium text-text-primary">
+                      권장 조치
+                    </p>
+                    <ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-text-secondary">
+                      {risk.risk_actions.map((action) => (
+                        <li key={action}>{action}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+
+                {risk.law_refs.length > 0 ? (
+                  <div className="mt-3 flex flex-wrap gap-2 text-xs text-text-secondary">
+                    {risk.law_refs.map((law) => (
+                      <span
+                        key={`${law.law_id ?? 'unknown'}-${law.article_no}`}
+                        className="rounded-md border border-border-soft px-2 py-1"
+                      >
+                        {law.law_type} {law.article_no}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+
+                {issueRefs.length > 0 ? (
+                  <div className="mt-3 space-y-1">
+                    {issueRefs.map((issue) => (
+                      <a
+                        key={issue.issue_id}
+                        href={normalizeIssueUrl(issue.url)}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="flex items-center gap-1 text-sm text-brand-primary hover:underline"
+                      >
+                        {issue.title}
+                        <ExternalLink className="h-3.5 w-3.5" />
+                      </a>
+                    ))}
+                  </div>
+                ) : null}
+              </section>
+            );
+          })}
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default LegalRiskResultModal;

--- a/src/hooks/useLegalRisk.ts
+++ b/src/hooks/useLegalRisk.ts
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { getLegalRisk, LegalRiskApiError } from '@/api/legalRisk';
+import type { LegalRiskRequest, LegalRiskResult } from '@/types/legalRisk';
+
+export const useLegalRisk = () => {
+  const [data, setData] = useState<LegalRiskResult | null>(null);
+  const [error, setError] = useState<LegalRiskApiError | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const requestLegalRisk = async (payload: LegalRiskRequest) => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const result = await getLegalRisk(payload);
+      setData(result);
+      return result;
+    } catch (requestError) {
+      const normalizedError =
+        requestError instanceof LegalRiskApiError
+          ? requestError
+          : new LegalRiskApiError('법률 리스크 조회 중 오류가 발생했습니다.');
+
+      setError(normalizedError);
+      setData(null);
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    data,
+    error,
+    isLoading,
+    requestLegalRisk,
+  };
+};

--- a/src/pages/ui/LawRiskPage.tsx
+++ b/src/pages/ui/LawRiskPage.tsx
@@ -1,149 +1,34 @@
-import { useState } from 'react';
-import { toast } from 'sonner';
 import { AlertTriangle } from 'lucide-react';
 import { Header } from '@/components/layout/Header';
-import { Card } from '@/components/common/Card';
-import { Input } from '@/components/common/input/Input';
-import { DropdownSelect } from '@/components/common/dropdown/DropdownSelect';
-import { Button } from '@/components/common/button/Button';
-import { RiskResultModal } from '@/components/risk/RiskResultModal';
+import { LegalRiskPanel } from '@/components/risk/LegalRiskPanel';
 
 export const LawRiskPage = () => {
-  const [stayCountry, setStayCountry] = useState('');
-  const [stayPurpose, setStayPurpose] = useState('');
-  const [visaType, setVisaType] = useState('');
-  const [age, setAge] = useState('');
-  const [showResult, setShowResult] = useState(false);
-
-  const handleAnalysis = () => {
-    if (!stayCountry || !stayPurpose || !visaType || age === '') {
-      toast.error('모든 필드를 입력해주세요.');
-      return;
-    }
-
-    const parsedAge = Number(age);
-    if (!Number.isFinite(parsedAge) || parsedAge < 0 || parsedAge > 120) {
-      toast.error('연령은 0~120세 범위로 입력해주세요.');
-      return;
-    }
-
-    setShowResult(true);
-  };
-
   return (
-    <div className="min-h-screen bg-bg-soft font-sans">
+    <div className="min-h-screen bg-gray-100 font-sans">
       <Header activeNavId="law-risk" />
 
-      <div className="flex h-[133px] w-full flex-col justify-center border-b border-border-subtle bg-white shadow-sm">
-        <div className="px-6 py-6 sm:px-10 lg:px-8">
-          <div className="flex items-center gap-3">
+      <div className="border-b border-gray-200 bg-white">
+        <div className="px-6 py-10 sm:px-8">
+          <div className="flex items-center gap-4">
             <AlertTriangle
-              className="h-8 w-8 text-brand-primary"
+              className="h-9 w-9 text-brand-primary"
               strokeWidth={2}
             />
-            <h1 className="text-[28px] font-medium leading-tight text-text-primary sm:text-[32px]">
+            <h1 className="text-[32px] font-medium leading-tight text-text-primary sm:text-[36px]">
               위험 지수
             </h1>
           </div>
-          <p className="mt-1 text-sm font-normal text-text-secondary sm:text-base">
+          <p className="mt-1 text-base text-text-secondary">
             체류 정보를 입력하시면 위험지수를 분석해드립니다
           </p>
         </div>
       </div>
 
-      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-        <Card className="bg-white p-6">
-          <div className="space-y-4">
-            <DropdownSelect
-              label="체류국가"
-              value={stayCountry}
-              onChange={(e) => setStayCountry(e.target.value)}
-              className="bg-gray-50"
-            >
-              <option value="" disabled>
-                체류국가를 선택하세요
-              </option>
-              <option value="미국">🇺🇸 미국</option>
-              <option value="중국">🇨🇳 중국</option>
-              <option value="일본">🇯🇵 일본</option>
-              <option value="독일">🇩🇪 독일</option>
-              <option value="영국">🇬🇧 영국</option>
-              <option value="프랑스">🇫🇷 프랑스</option>
-              <option value="베트남">🇻🇳 베트남</option>
-              <option value="인도">🇮🇳 인도</option>
-            </DropdownSelect>
-
-            <DropdownSelect
-              label="체류목적"
-              value={stayPurpose}
-              onChange={(e) => setStayPurpose(e.target.value)}
-              className="bg-gray-50"
-            >
-              <option value="" disabled>
-                체류목적을 선택하세요
-              </option>
-              <option value="취업">취업</option>
-              <option value="유학">유학</option>
-              <option value="사업">사업</option>
-              <option value="가족동반">가족동반</option>
-              <option value="관광">관광</option>
-              <option value="연수">연수</option>
-            </DropdownSelect>
-
-            <DropdownSelect
-              label="비자 종류"
-              value={visaType}
-              onChange={(e) => setVisaType(e.target.value)}
-              className="bg-gray-50"
-            >
-              <option value="" disabled>
-                비자 종류를 선택하세요
-              </option>
-              <option value="취업비자">취업비자</option>
-              <option value="학생비자">학생비자</option>
-              <option value="사업비자">사업비자</option>
-              <option value="동반비자">동반비자</option>
-              <option value="관광비자">관광비자</option>
-              <option value="워킹홀리데이">워킹홀리데이</option>
-            </DropdownSelect>
-
-            <div>
-              <label htmlFor="law-risk-age" className="mb-2 block text-sm">
-                연령
-              </label>
-              <Input
-                id="law-risk-age"
-                type="number"
-                min={0}
-                max={120}
-                step={1}
-                placeholder="연령을 입력하세요"
-                value={age}
-                onChange={(e) => setAge(e.target.value)}
-              />
-            </div>
-
-            <Button
-              type="button"
-              onClick={handleAnalysis}
-              disabled={!stayCountry || !stayPurpose || !visaType || age === ''}
-              className="w-full"
-            >
-              <AlertTriangle className="mr-2 h-4 w-4" />
-              위험 지수 분석하기
-            </Button>
-          </div>
-        </Card>
-      </div>
-
-      <RiskResultModal
-        open={showResult}
-        onClose={() => setShowResult(false)}
-        stayCountry={stayCountry}
-        stayPurpose={stayPurpose}
-        visaType={visaType}
-        age={age}
-      />
+      <main className="px-4 py-9 sm:px-6 lg:px-8">
+        <LegalRiskPanel />
+      </main>
     </div>
   );
 };
+
+export default LawRiskPage;

--- a/src/pages/ui/RiskPage.tsx
+++ b/src/pages/ui/RiskPage.tsx
@@ -1,0 +1,34 @@
+import { AlertTriangle } from 'lucide-react';
+import { Header } from '@/components/layout/Header';
+import { LegalRiskPanel } from '@/components/risk/LegalRiskPanel';
+
+export const RiskPage = () => {
+  return (
+    <div className="min-h-screen bg-gray-100 font-sans">
+      <Header activeNavId="risk" />
+
+      <div className="border-b border-gray-200 bg-white">
+        <div className="px-6 py-10 sm:px-8">
+          <div className="flex items-center gap-4">
+            <AlertTriangle
+              className="h-9 w-9 text-brand-primary"
+              strokeWidth={2}
+            />
+            <h1 className="text-[32px] font-medium leading-tight text-text-primary sm:text-[36px]">
+              위험 지수
+            </h1>
+          </div>
+          <p className="mt-1 text-base text-text-secondary">
+            체류 정보를 입력하시면 위험지수를 분석해드립니다
+          </p>
+        </div>
+      </div>
+
+      <main className="px-4 py-9 sm:px-6 lg:px-8">
+        <LegalRiskPanel />
+      </main>
+    </div>
+  );
+};
+
+export default RiskPage;

--- a/src/types/comparison.ts
+++ b/src/types/comparison.ts
@@ -16,6 +16,21 @@ export type ComparisonResult = {
   comparison: ComparisonAnalysis;
 };
 
+export type CompareLawRequest = {
+  country1: string;
+  country2: string;
+  topic: string;
+};
+
+export type CompareLawApiResponse = {
+  success: boolean;
+  status: number;
+  code: string;
+  message: string;
+  timestamp: string;
+  result: ComparisonResult | null;
+};
+
 export type CountryOption = {
   code: string;
   name: string;

--- a/src/types/legalRisk.ts
+++ b/src/types/legalRisk.ts
@@ -23,7 +23,7 @@ export type LegalRiskRequest = {
 };
 
 export type LawReference = {
-  law_id: number;
+  law_id: number | null;
   law_type: string;
   article_no: string;
 };

--- a/src/types/legalRisk.ts
+++ b/src/types/legalRisk.ts
@@ -1,0 +1,59 @@
+export type TravelPurpose = 'tourism' | 'business' | 'study' | 'work' | 'other';
+
+export type VisaType =
+  | 'short_stay'
+  | 'long_stay'
+  | 'visa_free'
+  | 'student'
+  | 'work'
+  | 'other';
+
+export type AgeBand = '10s' | '20s' | '30s' | '40s' | '50s' | '60s_plus';
+
+export type RiskLevel = 'LOW' | 'MEDIUM' | 'HIGH';
+
+export type LegalRiskRequest = {
+  country_id: number;
+  travel_purpose: TravelPurpose;
+  visa_type: VisaType;
+  age_band: AgeBand;
+};
+
+export type LawReference = {
+  law_id: number;
+  law_type: string;
+  article_no: string;
+};
+
+export type IssueReference = {
+  issue_id: number;
+  title: string;
+  url: string;
+  published_date: string;
+};
+
+export type LegalRiskItem = {
+  risk_title: string;
+  risk_level: RiskLevel;
+  risk_content: string;
+  risk_actions: string[];
+  law_refs: LawReference[];
+  issue_refs: IssueReference[];
+};
+
+export type LegalRiskResult = {
+  country_id: number;
+  overall_risk_level: RiskLevel;
+  risk_list: LegalRiskItem[];
+};
+
+export type ApiResponse<T> = {
+  success: boolean;
+  status: number;
+  code: string;
+  message: string;
+  timestamp: string;
+  result: T;
+};
+
+export type ApiErrorResponse = ApiResponse<null>;

--- a/src/types/legalRisk.ts
+++ b/src/types/legalRisk.ts
@@ -38,7 +38,7 @@ export type LegalRiskItem = {
   risk_content: string;
   risk_actions: string[];
   law_refs: LawReference[];
-  issue_refs: IssueReference[];
+  issue_refs?: IssueReference[];
 };
 
 export type LegalRiskResult = {

--- a/src/types/legalRisk.ts
+++ b/src/types/legalRisk.ts
@@ -1,14 +1,17 @@
-export type TravelPurpose = 'tourism' | 'business' | 'study' | 'work' | 'other';
+export type TravelPurpose =
+  | 'tourism'
+  | 'business'
+  | 'study'
+  | 'work'
+  | 'working_holiday';
 
 export type VisaType =
   | 'short_stay'
   | 'long_stay'
-  | 'visa_free'
-  | 'student'
-  | 'work'
-  | 'other';
+  | 'work_permit'
+  | 'student_visa';
 
-export type AgeBand = '10s' | '20s' | '30s' | '40s' | '50s' | '60s_plus';
+export type AgeBand = '10s' | '20s' | '30s' | '40s' | '50s_plus';
 
 export type RiskLevel = 'LOW' | 'MEDIUM' | 'HIGH';
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,23 +1,20 @@
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 // @ts-ignore
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import svgr from '@svgr/rollup';
 
 // https://vite.dev/config/
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '');
-
+export default defineConfig(() => {
   return {
     plugins: [react(), svgr()],
     server: {
       port: 3000,
       proxy: {
-        '/ai-api': {
-          target: env.VITE_API_BASE_URL,
+        '/ai': {
+          target: 'https://api.glaw.site',
           changeOrigin: true,
           secure: true,
-          rewrite: (reqPath) => reqPath.replace(/^\/ai-api/, '/ai'),
         },
       },
     },


### PR DESCRIPTION
## 작업 내용

- 법률 리스크 생성 API 연동을 위한 공통 API 클라이언트 추가
- `POST /api/risk` 요청/응답 타입 정의
- 법률 리스크 조회 훅 추가
- AI 법률 상담 화면에 리스크 조회 UI 연결
- 조회 결과의 종합 리스크, 리스크 목록, 권장 조치, 법령 근거, 이슈 참고 링크 표시
- 기존 `Badge` 컴포넌트의 `tag` variant 타입 누락 수정

## API 연동 정보

- Base URL: `https://api.glaw.site`
- Endpoint: `POST /api/risk`
- Request body:
  - `country_id`
  - `travel_purpose`
  - `visa_type`
  - `age_band`

## 테스트

- `npx tsc -b` 통과

## 참고 사항

- API 경로는 `.env.example`의 `VITE_LEGAL_RISK_PATH=/api/risk`로 관리하도록 추가했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 법률 리스크 페이지(입력 폼, 위험지수 분석·배지, 항목별 카드, 권장조치·링크) 추가.
  * 법률 비교 페이지(비교 폼, 결과 모달, 공통점·차이점 분석·하이라이트, 국가별 요약·관련 법 태그) 추가.
  * 비교·리스크용 상태 훅 및 텍스트 하이라이트 유틸 추가.

* **Documentation**
  * 개발용 환경변수 예시 항목 3개 추가.

* **Chores**
  * 개발 서버 프록시 구성 추가 및 레이아웃/배지 옵션 조정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->