### PR TITLE
[feat] 로그인, 회원가입 API 연동

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -6,13 +6,11 @@ export type OnboardingRequest = {
 };
 
 export const OAUTH_LOGIN_STARTED_KEY = 'glaw:oauth-login-started';
-export const AUTH_CHECKED_KEY = 'glaw:auth-checked';
 
 export const startGoogleLogin = (): void => {
   if (typeof window === 'undefined') return;
 
   const loginUrl = new URL(env.googleLoginUrl, window.location.origin);
-  window.sessionStorage.removeItem(AUTH_CHECKED_KEY);
   window.sessionStorage.setItem(OAUTH_LOGIN_STARTED_KEY, 'true');
   window.location.href = loginUrl.toString();
 };

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -6,11 +6,13 @@ export type OnboardingRequest = {
 };
 
 export const OAUTH_LOGIN_STARTED_KEY = 'glaw:oauth-login-started';
+export const AUTH_CHECKED_KEY = 'glaw:auth-checked';
 
 export const startGoogleLogin = (): void => {
   if (typeof window === 'undefined') return;
 
   const loginUrl = new URL(env.googleLoginUrl, window.location.origin);
+  window.sessionStorage.removeItem(AUTH_CHECKED_KEY);
   window.sessionStorage.setItem(OAUTH_LOGIN_STARTED_KEY, 'true');
   window.location.href = loginUrl.toString();
 };

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -12,7 +12,7 @@ export const startGoogleLogin = (): void => {
     env.loginRedirectUrl ??
     `${window.location.origin.replace(/\/$/, '')}/onboarding`;
 
-  const loginUrl = new URL(env.googleLoginUrl);
+  const loginUrl = new URL(env.googleLoginUrl, window.location.origin);
   loginUrl.searchParams.set('redirect_uri', redirectUrl);
   window.location.href = loginUrl.toString();
 };

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -10,9 +10,8 @@ export const OAUTH_LOGIN_STARTED_KEY = 'glaw:oauth-login-started';
 export const startGoogleLogin = (): void => {
   if (typeof window === 'undefined') return;
 
-  window.sessionStorage.setItem(OAUTH_LOGIN_STARTED_KEY, 'true');
-
   const loginUrl = new URL(env.googleLoginUrl, window.location.origin);
+  window.sessionStorage.setItem(OAUTH_LOGIN_STARTED_KEY, 'true');
   window.location.href = loginUrl.toString();
 };
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,30 @@
+import apiClient from '@/lib/apiClient';
+import env from '@/lib/env';
+
+export type OnboardingRequest = {
+  countryIds: number[];
+};
+
+export const startGoogleLogin = (): void => {
+  if (typeof window === 'undefined') return;
+
+  const redirectUrl =
+    env.loginRedirectUrl ??
+    `${window.location.origin.replace(/\/$/, '')}/onboarding`;
+
+  const loginUrl = new URL(env.googleLoginUrl);
+  loginUrl.searchParams.set('redirect_uri', redirectUrl);
+  window.location.href = loginUrl.toString();
+};
+
+export const logout = async (): Promise<void> => {
+  await apiClient.post('/api/auth/logout');
+};
+
+export const reissue = async (): Promise<void> => {
+  await apiClient.post('/api/auth/reissue');
+};
+
+export const onboarding = async (payload: OnboardingRequest): Promise<void> => {
+  await apiClient.post('/api/auth/onboarding', payload);
+};

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -5,15 +5,14 @@ export type OnboardingRequest = {
   countryIds: number[];
 };
 
+export const OAUTH_LOGIN_STARTED_KEY = 'glaw:oauth-login-started';
+
 export const startGoogleLogin = (): void => {
   if (typeof window === 'undefined') return;
 
-  const redirectUrl =
-    env.loginRedirectUrl ??
-    `${window.location.origin.replace(/\/$/, '')}/onboarding`;
+  window.sessionStorage.setItem(OAUTH_LOGIN_STARTED_KEY, 'true');
 
   const loginUrl = new URL(env.googleLoginUrl, window.location.origin);
-  loginUrl.searchParams.set('redirect_uri', redirectUrl);
   window.location.href = loginUrl.toString();
 };
 

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,0 +1,29 @@
+import apiClient from '@/lib/apiClient';
+
+export type UserRole = 'ROLE_GUEST' | 'ROLE_USER';
+
+export type UserCountry = {
+  countryId: number;
+  code: string;
+  name: string;
+  stateCode?: string;
+  stateName?: string;
+};
+
+export type UserMe = {
+  userId: number;
+  email: string;
+  name: string;
+  role: UserRole;
+  countries: UserCountry[];
+};
+
+type ApiResponse<T> = {
+  result: T;
+};
+
+export const getMyInfo = async (): Promise<UserMe> => {
+  const { data } = await apiClient.get<ApiResponse<UserMe>>('/api/users/me');
+  return data.result;
+};
+

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -22,8 +22,17 @@ type ApiResponse<T> = {
   result: T;
 };
 
+export type UpdateUserCountriesRequest = {
+  countryIds: number[];
+};
+
 export const getMyInfo = async (): Promise<UserMe> => {
   const { data } = await apiClient.get<ApiResponse<UserMe>>('/api/users/me');
   return data.result;
 };
 
+export const updateUserCountries = async (
+  payload: UpdateUserCountriesRequest,
+): Promise<void> => {
+  await apiClient.patch('/api/users/countries', payload);
+};

--- a/src/components/mypage/InterestsTab.tsx
+++ b/src/components/mypage/InterestsTab.tsx
@@ -11,6 +11,7 @@ type InterestsTabProps = {
   onToggleInterest: (code: PreferredCountries[number]) => void;
   onSave: () => void;
   onCancel: () => void;
+  isSaving?: boolean;
 };
 
 export const InterestsTab = ({
@@ -20,6 +21,7 @@ export const InterestsTab = ({
   onToggleInterest,
   onSave,
   onCancel,
+  isSaving = false,
 }: InterestsTabProps) => (
   <Card className="rounded-2xl border-border-subtle bg-white px-5 py-5 shadow-sm sm:px-6 sm:py-6">
     <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -32,6 +34,7 @@ export const InterestsTab = ({
               size="sm"
               className="border-border-base text-text-secondary hover:border-border-selected"
               onClick={onCancel}
+              disabled={isSaving}
             >
               취소
             </Button>
@@ -39,8 +42,9 @@ export const InterestsTab = ({
               size="sm"
               className="bg-brand-primary px-4 text-white hover:brightness-95"
               onClick={onSave}
+              disabled={isSaving}
             >
-              저장
+              {isSaving ? '저장 중...' : '저장'}
             </Button>
           </>
         ) : (
@@ -65,7 +69,7 @@ export const InterestsTab = ({
             key={country.code}
             type="button"
             onClick={() => onToggleInterest(country.code)}
-            disabled={!isEditing}
+            disabled={!isEditing || isSaving}
             aria-pressed={isSelected}
             className={`flex items-center justify-between rounded-xl border px-4 py-3 text-left transition ${
               isSelected

--- a/src/constants/interestCountries.ts
+++ b/src/constants/interestCountries.ts
@@ -7,6 +7,8 @@ export type InterestCountry = {
 // 관심 국가 선택 모달과 뉴스 필터에서 사용하는 ISO 국가 코드 순서형 데이터
 export const INTEREST_COUNTRIES: InterestCountry[] = [
   { code: 'US', name: '미국', flag: '🇺🇸' },
+  { code: 'CA', name: '캐나다', flag: '🇨🇦' },
+  { code: 'AU', name: '호주', flag: '🇦🇺' },
   { code: 'JP', name: '일본', flag: '🇯🇵' },
   { code: 'CN', name: '중국', flag: '🇨🇳' },
   { code: 'GB', name: '영국', flag: '🇬🇧' },
@@ -15,8 +17,6 @@ export const INTEREST_COUNTRIES: InterestCountry[] = [
   { code: 'TH', name: '태국', flag: '🇹🇭' },
   { code: 'VN', name: '베트남', flag: '🇻🇳' },
   { code: 'SG', name: '싱가포르', flag: '🇸🇬' },
-  { code: 'AU', name: '호주', flag: '🇦🇺' },
-  { code: 'CA', name: '캐나다', flag: '🇨🇦' },
   { code: 'ES', name: '스페인', flag: '🇪🇸' },
 ] as const;
 

--- a/src/hooks/useAuthFlow.ts
+++ b/src/hooks/useAuthFlow.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
-  AUTH_CHECKED_KEY,
   OAUTH_LOGIN_STARTED_KEY,
   logout,
   onboarding,
@@ -21,12 +20,13 @@ const VALID_COUNTRY_CODES = new Set(
   INTEREST_COUNTRIES.map((country) => country.code),
 );
 const AUTH_SESSION_KEY = 'glaw:has-auth-session';
+let hasCheckedAuthInCurrentLoad = false;
 
 const shouldCheckAuthOnRoute = (): boolean => {
   if (typeof window === 'undefined') return false;
 
   return (
-    window.sessionStorage.getItem(AUTH_CHECKED_KEY) !== 'true' ||
+    !hasCheckedAuthInCurrentLoad ||
     window.sessionStorage.getItem(OAUTH_LOGIN_STARTED_KEY) === 'true' ||
     window.localStorage.getItem(AUTH_SESSION_KEY) === 'true'
   );
@@ -42,7 +42,6 @@ const forgetAuthSession = () => {
   if (typeof window === 'undefined') return;
   window.localStorage.removeItem(AUTH_SESSION_KEY);
   window.sessionStorage.removeItem(OAUTH_LOGIN_STARTED_KEY);
-  window.sessionStorage.setItem(AUTH_CHECKED_KEY, 'true');
 };
 
 const getApiErrorCode = (error: unknown): string | undefined => {
@@ -134,15 +133,18 @@ export const useAuthFlow = () => {
       try {
         const me = await getMyInfo();
         if (!isMounted) return;
+        hasCheckedAuthInCurrentLoad = true;
         applyMyInfo(me);
       } catch {
         try {
           await reissue();
           const me = await getMyInfo();
           if (!isMounted) return;
+          hasCheckedAuthInCurrentLoad = true;
           applyMyInfo(me);
         } catch {
           if (!isMounted) return;
+          hasCheckedAuthInCurrentLoad = true;
           forgetAuthSession();
           clearPreferredCountries();
           setModalSelection([]);

--- a/src/hooks/useAuthFlow.ts
+++ b/src/hooks/useAuthFlow.ts
@@ -121,8 +121,6 @@ export const useAuthFlow = () => {
     if (!shouldCheckAuthOnRoute()) {
       clearPreferredCountries();
       setModalSelection([]);
-      setAuthStatus('anonymous');
-      return;
     }
 
     let isMounted = true;

--- a/src/hooks/useAuthFlow.ts
+++ b/src/hooks/useAuthFlow.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
+  AUTH_CHECKED_KEY,
   OAUTH_LOGIN_STARTED_KEY,
   logout,
   onboarding,
@@ -25,6 +26,7 @@ const shouldCheckAuthOnRoute = (): boolean => {
   if (typeof window === 'undefined') return false;
 
   return (
+    window.sessionStorage.getItem(AUTH_CHECKED_KEY) !== 'true' ||
     window.sessionStorage.getItem(OAUTH_LOGIN_STARTED_KEY) === 'true' ||
     window.localStorage.getItem(AUTH_SESSION_KEY) === 'true'
   );
@@ -40,6 +42,7 @@ const forgetAuthSession = () => {
   if (typeof window === 'undefined') return;
   window.localStorage.removeItem(AUTH_SESSION_KEY);
   window.sessionStorage.removeItem(OAUTH_LOGIN_STARTED_KEY);
+  window.sessionStorage.setItem(AUTH_CHECKED_KEY, 'true');
 };
 
 const getApiErrorCode = (error: unknown): string | undefined => {
@@ -121,6 +124,8 @@ export const useAuthFlow = () => {
     if (!shouldCheckAuthOnRoute()) {
       clearPreferredCountries();
       setModalSelection([]);
+      setAuthStatus('anonymous');
+      return;
     }
 
     let isMounted = true;

--- a/src/hooks/useAuthFlow.ts
+++ b/src/hooks/useAuthFlow.ts
@@ -21,9 +21,8 @@ const VALID_COUNTRY_CODES = new Set(
 );
 const AUTH_SESSION_KEY = 'glaw:has-auth-session';
 
-const shouldCheckAuthOnRoute = (pathname: string): boolean => {
+const shouldCheckAuthOnRoute = (): boolean => {
   if (typeof window === 'undefined') return false;
-  if (pathname === '/login') return false;
 
   return (
     window.sessionStorage.getItem(OAUTH_LOGIN_STARTED_KEY) === 'true' ||
@@ -88,25 +87,38 @@ export const useAuthFlow = () => {
     [savePreferredCountries],
   );
 
+  const completeOnboarding = useCallback(
+    async (countryIds: number[]) => {
+      setIsOnboardingSaving(true);
+      try {
+        await onboarding({ countryIds });
+        const me = await getMyInfo();
+        applyMyInfo(me);
+
+        if (me.role === 'ROLE_USER') {
+          void navigate('/');
+        }
+      } catch (error) {
+        if (getApiErrorCode(error) === 'ONBOARDING_ALREADY_COMPLETED') {
+          try {
+            const me = await getMyInfo();
+            applyMyInfo(me);
+            void navigate('/');
+            return;
+          } catch {
+            // Fall through to the generic error message.
+          }
+        }
+        window.alert('온보딩 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      } finally {
+        setIsOnboardingSaving(false);
+      }
+    },
+    [applyMyInfo, navigate],
+  );
+
   useEffect(() => {
-    if (location.pathname === '/login') {
-      forgetAuthSession();
-      clearPreferredCountries();
-      setModalSelection([]);
-      setAuthStatus('anonymous');
-      return;
-    }
-
-    if (
-      location.pathname === '/onboarding' &&
-      typeof window !== 'undefined' &&
-      window.sessionStorage.getItem(OAUTH_LOGIN_STARTED_KEY) === 'true'
-    ) {
-      setAuthStatus('guest');
-      return;
-    }
-
-    if (!shouldCheckAuthOnRoute(location.pathname)) {
+    if (!shouldCheckAuthOnRoute()) {
       clearPreferredCountries();
       setModalSelection([]);
       setAuthStatus('anonymous');
@@ -142,7 +154,7 @@ export const useAuthFlow = () => {
   }, [applyMyInfo, clearPreferredCountries, location.pathname]);
 
   const handleSkipInterest = () => {
-    window.alert('온보딩 완료 후 서비스를 이용할 수 있습니다.');
+    void completeOnboarding([]);
   };
 
   const handleGoogleLogin = () => {
@@ -163,30 +175,7 @@ export const useAuthFlow = () => {
         return;
       }
 
-      setIsOnboardingSaving(true);
-      try {
-        await onboarding({ countryIds });
-        const me = await getMyInfo();
-        applyMyInfo(me);
-
-        if (me.role === 'ROLE_USER') {
-          void navigate('/');
-        }
-      } catch (error) {
-        if (getApiErrorCode(error) === 'ONBOARDING_ALREADY_COMPLETED') {
-          try {
-            const me = await getMyInfo();
-            applyMyInfo(me);
-            void navigate('/');
-            return;
-          } catch {
-            // Fall through to the generic error message.
-          }
-        }
-        window.alert('온보딩 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.');
-      } finally {
-        setIsOnboardingSaving(false);
-      }
+      await completeOnboarding(countryIds);
     })();
   };
 

--- a/src/hooks/useAuthFlow.ts
+++ b/src/hooks/useAuthFlow.ts
@@ -1,0 +1,245 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import {
+  OAUTH_LOGIN_STARTED_KEY,
+  logout,
+  onboarding,
+  reissue,
+  startGoogleLogin,
+} from '@/api/auth';
+import { getMyInfo, updateUserCountries } from '@/api/user';
+import { INTEREST_COUNTRIES } from '@/constants/interestCountries';
+import env from '@/lib/env';
+import { mapCountryCodesToIds } from '@/lib/countryIds';
+import { usePreferredCountries } from '@/hooks/usePreferredCountries';
+import type { CountryCode } from '@/types/country';
+
+export type AuthStatus = 'checking' | 'anonymous' | 'guest' | 'user';
+
+const VALID_COUNTRY_CODES = new Set(
+  INTEREST_COUNTRIES.map((country) => country.code),
+);
+const AUTH_SESSION_KEY = 'glaw:has-auth-session';
+
+const shouldCheckAuthOnRoute = (pathname: string): boolean => {
+  if (typeof window === 'undefined') return false;
+  if (pathname === '/login') return false;
+
+  return (
+    window.sessionStorage.getItem(OAUTH_LOGIN_STARTED_KEY) === 'true' ||
+    window.localStorage.getItem(AUTH_SESSION_KEY) === 'true'
+  );
+};
+
+const rememberAuthSession = () => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(AUTH_SESSION_KEY, 'true');
+  window.sessionStorage.removeItem(OAUTH_LOGIN_STARTED_KEY);
+};
+
+const forgetAuthSession = () => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.removeItem(AUTH_SESSION_KEY);
+  window.sessionStorage.removeItem(OAUTH_LOGIN_STARTED_KEY);
+};
+
+const getApiErrorCode = (error: unknown): string | undefined => {
+  if (!error || typeof error !== 'object') return undefined;
+
+  const response = (error as { response?: { data?: { code?: unknown } } })
+    .response;
+  return typeof response?.data?.code === 'string'
+    ? response.data.code
+    : undefined;
+};
+
+const normalizeCountryCodes = (codes: string[]): CountryCode[] =>
+  Array.from(
+    new Set(
+      codes
+        .map((code) => code.toUpperCase())
+        .filter((code): code is CountryCode => VALID_COUNTRY_CODES.has(code)),
+    ),
+  );
+
+export const useAuthFlow = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const {
+    preferredCountries,
+    savePreferredCountries,
+    clearPreferredCountries,
+  } = usePreferredCountries();
+
+  const [authStatus, setAuthStatus] = useState<AuthStatus>('checking');
+  const [modalSelection, setModalSelection] = useState(preferredCountries);
+  const [isOnboardingSaving, setIsOnboardingSaving] = useState(false);
+
+  const applyMyInfo = useCallback(
+    (me: Awaited<ReturnType<typeof getMyInfo>>) => {
+      const codes = normalizeCountryCodes(
+        me.countries.map((country) => country.code),
+      );
+      rememberAuthSession();
+      savePreferredCountries(codes);
+      setModalSelection(codes);
+      setAuthStatus(me.role === 'ROLE_GUEST' ? 'guest' : 'user');
+    },
+    [savePreferredCountries],
+  );
+
+  useEffect(() => {
+    if (location.pathname === '/login') {
+      forgetAuthSession();
+      clearPreferredCountries();
+      setModalSelection([]);
+      setAuthStatus('anonymous');
+      return;
+    }
+
+    if (
+      location.pathname === '/onboarding' &&
+      typeof window !== 'undefined' &&
+      window.sessionStorage.getItem(OAUTH_LOGIN_STARTED_KEY) === 'true'
+    ) {
+      setAuthStatus('guest');
+      return;
+    }
+
+    if (!shouldCheckAuthOnRoute(location.pathname)) {
+      clearPreferredCountries();
+      setModalSelection([]);
+      setAuthStatus('anonymous');
+      return;
+    }
+
+    let isMounted = true;
+
+    void (async () => {
+      try {
+        const me = await getMyInfo();
+        if (!isMounted) return;
+        applyMyInfo(me);
+      } catch {
+        try {
+          await reissue();
+          const me = await getMyInfo();
+          if (!isMounted) return;
+          applyMyInfo(me);
+        } catch {
+          if (!isMounted) return;
+          forgetAuthSession();
+          clearPreferredCountries();
+          setModalSelection([]);
+          setAuthStatus('anonymous');
+        }
+      }
+    })();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [applyMyInfo, clearPreferredCountries, location.pathname]);
+
+  const handleSkipInterest = () => {
+    window.alert('온보딩 완료 후 서비스를 이용할 수 있습니다.');
+  };
+
+  const handleGoogleLogin = () => {
+    startGoogleLogin();
+  };
+
+  const handleSaveInterest = (countries: CountryCode[]) => {
+    void (async () => {
+      const { countryIds, missingCodes } = mapCountryCodesToIds(
+        countries,
+        env.countryIdMap,
+      );
+
+      if (missingCodes.length > 0) {
+        window.alert(
+          `countryId 매핑이 없는 국가가 있습니다: ${missingCodes.join(', ')}`,
+        );
+        return;
+      }
+
+      setIsOnboardingSaving(true);
+      try {
+        await onboarding({ countryIds });
+        const me = await getMyInfo();
+        applyMyInfo(me);
+
+        if (me.role === 'ROLE_USER') {
+          void navigate('/');
+        }
+      } catch (error) {
+        if (getApiErrorCode(error) === 'ONBOARDING_ALREADY_COMPLETED') {
+          try {
+            const me = await getMyInfo();
+            applyMyInfo(me);
+            void navigate('/');
+            return;
+          } catch {
+            // Fall through to the generic error message.
+          }
+        }
+        window.alert('온보딩 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      } finally {
+        setIsOnboardingSaving(false);
+      }
+    })();
+  };
+
+  const handleSavePreferredCountries = async (countries: CountryCode[]) => {
+    const { countryIds, missingCodes } = mapCountryCodesToIds(
+      countries,
+      env.countryIdMap,
+    );
+
+    if (missingCodes.length > 0) {
+      window.alert(
+        `countryId 매핑이 없는 국가가 있습니다: ${missingCodes.join(', ')}`,
+      );
+      throw new Error('Missing countryId mapping');
+    }
+
+    try {
+      await updateUserCountries({ countryIds });
+      const me = await getMyInfo();
+      applyMyInfo(me);
+    } catch {
+      window.alert('관심 국가 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      throw new Error('Failed to update user countries');
+    }
+  };
+
+  const handleLogout = () => {
+    void (async () => {
+      try {
+        await logout();
+      } finally {
+        clearPreferredCountries();
+        forgetAuthSession();
+        if (typeof window !== 'undefined') {
+          window.localStorage.removeItem('savedLaws');
+        }
+        setAuthStatus('anonymous');
+        void navigate('/login');
+      }
+    })();
+  };
+
+  return {
+    authStatus,
+    preferredCountries,
+    modalSelection,
+    isOnboardingSaving,
+    handleGoogleLogin,
+    handleSkipInterest,
+    handleSaveInterest,
+    handleSavePreferredCountries,
+    handleLogout,
+  };
+};
+
+export default useAuthFlow;

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -4,10 +4,10 @@ import env from '@/lib/env';
 export const apiClient = axios.create({
   baseURL: env.apiBaseUrl,
   withCredentials: true,
+  timeout: 10000,
   headers: {
     'Content-Type': 'application/json',
   },
 });
 
 export default apiClient;
-

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+import env from '@/lib/env';
+
+export const apiClient = axios.create({
+  baseURL: env.apiBaseUrl,
+  withCredentials: true,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export default apiClient;
+

--- a/src/lib/chatCountryIds.ts
+++ b/src/lib/chatCountryIds.ts
@@ -1,43 +1,12 @@
 import type { CountryCode } from '@/types/country';
+import env from '@/lib/env';
 
 const DEFAULT_COUNTRY_CODE: CountryCode = 'US';
-const DEFAULT_COUNTRY_ID_MAP: Partial<Record<CountryCode, number>> = {
-  US: 1,
-  CA: 4,
-  AU: 7,
-};
-
-const parseCountryIdMap = (): Partial<Record<CountryCode, number>> => {
-  const value = import.meta.env.VITE_COUNTRY_ID_MAP;
-
-  if (!value) {
-    return DEFAULT_COUNTRY_ID_MAP;
-  }
-
-  try {
-    const parsed = JSON.parse(value) as Partial<Record<CountryCode, unknown>>;
-
-    return Object.entries(parsed).reduce<Partial<Record<CountryCode, number>>>(
-      (acc, [countryCode, countryId]) => {
-        if (typeof countryId === 'number' && Number.isFinite(countryId)) {
-          acc[countryCode] = countryId;
-        }
-
-        return acc;
-      },
-      {},
-    );
-  } catch {
-    return DEFAULT_COUNTRY_ID_MAP;
-  }
-};
-
-const CHAT_COUNTRY_ID_MAP = parseCountryIdMap();
 
 export const getChatCountryId = (
   countryCode?: CountryCode,
 ): number | null => {
   const targetCountryCode = countryCode ?? DEFAULT_COUNTRY_CODE;
 
-  return CHAT_COUNTRY_ID_MAP[targetCountryCode] ?? null;
+  return env.countryIdMap[targetCountryCode] ?? null;
 };

--- a/src/lib/chatCountryIds.ts
+++ b/src/lib/chatCountryIds.ts
@@ -3,7 +3,8 @@ import type { CountryCode } from '@/types/country';
 const DEFAULT_COUNTRY_CODE: CountryCode = 'US';
 const DEFAULT_COUNTRY_ID_MAP: Partial<Record<CountryCode, number>> = {
   US: 1,
-  CA: 2,
+  CA: 4,
+  AU: 7,
 };
 
 const parseCountryIdMap = (): Partial<Record<CountryCode, number>> => {
@@ -19,7 +20,7 @@ const parseCountryIdMap = (): Partial<Record<CountryCode, number>> => {
     return Object.entries(parsed).reduce<Partial<Record<CountryCode, number>>>(
       (acc, [countryCode, countryId]) => {
         if (typeof countryId === 'number' && Number.isFinite(countryId)) {
-          acc[countryCode as CountryCode] = countryId;
+          acc[countryCode] = countryId;
         }
 
         return acc;

--- a/src/lib/countryIds.ts
+++ b/src/lib/countryIds.ts
@@ -16,7 +16,7 @@ export const mapCountryCodesToIds = (
 
   codes.forEach((code) => {
     const countryId = countryIdMap[code];
-    if (typeof countryId === 'number') {
+    if (typeof countryId === 'number' && Number.isFinite(countryId)) {
       countryIds.push(countryId);
       return;
     }

--- a/src/lib/countryIds.ts
+++ b/src/lib/countryIds.ts
@@ -1,0 +1,31 @@
+import type { CountryCode } from '@/types/country';
+
+type CountryIdMap = Record<string, number>;
+
+export type CountryIdMappingResult = {
+  countryIds: number[];
+  missingCodes: CountryCode[];
+};
+
+export const mapCountryCodesToIds = (
+  codes: CountryCode[],
+  countryIdMap: CountryIdMap,
+): CountryIdMappingResult => {
+  const countryIds: number[] = [];
+  const missingCodes: CountryCode[] = [];
+
+  codes.forEach((code) => {
+    const countryId = countryIdMap[code];
+    if (typeof countryId === 'number') {
+      countryIds.push(countryId);
+      return;
+    }
+    missingCodes.push(code);
+  });
+
+  return {
+    countryIds,
+    missingCodes,
+  };
+};
+

--- a/src/lib/countryIds.ts
+++ b/src/lib/countryIds.ts
@@ -11,6 +11,14 @@ export const mapCountryCodesToIds = (
   codes: CountryCode[],
   countryIdMap: CountryIdMap,
 ): CountryIdMappingResult => {
+  // Backend temporary policy: only country_id=1 is valid.
+  if (codes.length > 0) {
+    return {
+      countryIds: [1],
+      missingCodes: [],
+    };
+  }
+
   const countryIds: number[] = [];
   const missingCodes: CountryCode[] = [];
 
@@ -28,4 +36,3 @@ export const mapCountryCodesToIds = (
     missingCodes,
   };
 };
-

--- a/src/lib/countryIds.ts
+++ b/src/lib/countryIds.ts
@@ -11,14 +11,6 @@ export const mapCountryCodesToIds = (
   codes: CountryCode[],
   countryIdMap: CountryIdMap,
 ): CountryIdMappingResult => {
-  // Backend temporary policy: only country_id=1 is valid.
-  if (codes.length > 0) {
-    return {
-      countryIds: [1],
-      missingCodes: [],
-    };
-  }
-
   const countryIds: number[] = [];
   const missingCodes: CountryCode[] = [];
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -5,10 +5,16 @@ const requiredEnv = (value: string | undefined, key: string): string => {
   return value;
 };
 
+const DEFAULT_COUNTRY_ID_MAP: Record<string, number> = {
+  US: 1,
+  CA: 4,
+  AU: 7,
+};
+
 const parseCountryIdMap = (
   value: string | undefined,
 ): Record<string, number> => {
-  if (!value) return {};
+  if (!value) return DEFAULT_COUNTRY_ID_MAP;
 
   try {
     const parsed = JSON.parse(value) as Record<string, unknown>;
@@ -16,14 +22,20 @@ const parseCountryIdMap = (
       (acc, [code, id]) => {
         if (typeof id === 'number' && Number.isFinite(id)) {
           acc[code.toUpperCase()] = id;
+          return acc;
         }
-        return acc;
+        throw new Error(`Invalid country id mapping for ${code}`);
       },
       {},
     );
-  } catch {
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error(
+        'Invalid VITE_COUNTRY_ID_MAP. Use JSON object format, e.g. {"US":1,"JP":2}',
+      );
+    }
     throw new Error(
-      'Invalid VITE_COUNTRY_ID_MAP. Use JSON object format, e.g. {"US":1,"JP":2}',
+      'Invalid VITE_COUNTRY_ID_MAP. Country IDs must be finite numbers.',
     );
   }
 };

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,8 +1,9 @@
-const requiredEnv = (value: string | undefined, key: string): string => {
-  if (!value) {
-    throw new Error(`Missing required environment variable: ${key}`);
-  }
-  return value;
+const getEnvValue = (value: string | undefined, fallback: string): string =>
+  value ?? fallback;
+
+const getDefaultApiBaseUrl = (): string => {
+  if (typeof window === 'undefined') return '';
+  return window.location.origin;
 };
 
 const DEFAULT_COUNTRY_ID_MAP: Record<string, number> = {
@@ -41,13 +42,13 @@ const parseCountryIdMap = (
 };
 
 export const env = {
-  apiBaseUrl: requiredEnv(
+  apiBaseUrl: getEnvValue(
     import.meta.env.VITE_API_BASE_URL,
-    'VITE_API_BASE_URL',
+    getDefaultApiBaseUrl(),
   ),
-  googleLoginUrl: requiredEnv(
+  googleLoginUrl: getEnvValue(
     import.meta.env.VITE_GOOGLE_LOGIN_URL,
-    'VITE_GOOGLE_LOGIN_URL',
+    '/oauth2/authorization/google',
   ),
   loginRedirectUrl: import.meta.env.VITE_LOGIN_REDIRECT_URL,
   countryIdMap: parseCountryIdMap(import.meta.env.VITE_COUNTRY_ID_MAP),

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,44 @@
+const requiredEnv = (value: string | undefined, key: string): string => {
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+  return value;
+};
+
+const parseCountryIdMap = (
+  value: string | undefined,
+): Record<string, number> => {
+  if (!value) return {};
+
+  try {
+    const parsed = JSON.parse(value) as Record<string, unknown>;
+    return Object.entries(parsed).reduce<Record<string, number>>(
+      (acc, [code, id]) => {
+        if (typeof id === 'number' && Number.isFinite(id)) {
+          acc[code.toUpperCase()] = id;
+        }
+        return acc;
+      },
+      {},
+    );
+  } catch {
+    throw new Error(
+      'Invalid VITE_COUNTRY_ID_MAP. Use JSON object format, e.g. {"US":1,"JP":2}',
+    );
+  }
+};
+
+export const env = {
+  apiBaseUrl: requiredEnv(
+    import.meta.env.VITE_API_BASE_URL,
+    'VITE_API_BASE_URL',
+  ),
+  googleLoginUrl: requiredEnv(
+    import.meta.env.VITE_GOOGLE_LOGIN_URL,
+    'VITE_GOOGLE_LOGIN_URL',
+  ),
+  loginRedirectUrl: import.meta.env.VITE_LOGIN_REDIRECT_URL,
+  countryIdMap: parseCountryIdMap(import.meta.env.VITE_COUNTRY_ID_MAP),
+};
+
+export default env;

--- a/src/pages/ui/MyPage.tsx
+++ b/src/pages/ui/MyPage.tsx
@@ -27,7 +27,7 @@ import { CompareTab } from '@/components/mypage/CompareTab';
 
 type MyPageProps = {
   preferredCountries: PreferredCountries;
-  onSavePreferredCountries: (countries: PreferredCountries) => void;
+  onSavePreferredCountries: (countries: PreferredCountries) => Promise<void>;
   onLogout: () => void;
 };
 
@@ -38,6 +38,7 @@ export const MyPage = ({
 }: MyPageProps) => {
   const [activeTab, setActiveTab] = useState<string>('interests');
   const [isEditingInterests, setIsEditingInterests] = useState(false);
+  const [isSavingInterests, setIsSavingInterests] = useState(false);
   const [interestSelection, setInterestSelection] =
     useState<PreferredCountries>(preferredCountries);
   const [compareSets, setCompareSets] = useState<CompareSet[]>(mockCompareSets);
@@ -73,8 +74,17 @@ export const MyPage = ({
   };
 
   const handleSaveInterests = () => {
-    onSavePreferredCountries(interestSelection);
-    setIsEditingInterests(false);
+    void (async () => {
+      setIsSavingInterests(true);
+      try {
+        await onSavePreferredCountries(interestSelection);
+        setIsEditingInterests(false);
+      } catch {
+        // The route-level handler shows the user-facing error.
+      } finally {
+        setIsSavingInterests(false);
+      }
+    })();
   };
 
   const handleCancelInterests = () => {
@@ -174,6 +184,7 @@ export const MyPage = ({
               onToggleInterest={toggleInterest}
               onSave={handleSaveInterests}
               onCancel={handleCancelInterests}
+              isSaving={isSavingInterests}
             />
           </DashboardTabsContent>
 

--- a/src/pages/ui/MyPage.tsx
+++ b/src/pages/ui/MyPage.tsx
@@ -80,7 +80,7 @@ export const MyPage = ({
         await onSavePreferredCountries(interestSelection);
         setIsEditingInterests(false);
       } catch {
-        // The route-level handler shows the user-facing error.
+        // useAuthFlow shows the user-facing error via window.alert.
       } finally {
         setIsSavingInterests(false);
       }

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -1,148 +1,363 @@
-import { useEffect, useState } from 'react';
-import { Navigate, Route, Routes, useNavigate } from 'react-router-dom';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Navigate,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+} from 'react-router-dom';
 import { LoginPage } from '@/pages/ui/LoginPage';
 import { InterestCountryModal } from '@/components/interest/InterestCountryModal';
 import { usePreferredCountries } from '@/hooks/usePreferredCountries';
-import { CountryCode } from '@/types/country';
+import type { CountryCode } from '@/types/country';
 import { MyPage } from '@/pages/ui/MyPage';
 import { AiChatPage } from '@/pages/ui/AiChatPage';
 import { LawComparisonPage } from '@/pages/ui/LawComparisonPage';
 import { MainDashboardPage } from '@/pages/ui/MainDashboardPage';
 import { LawCollectionPage } from '@/pages/ui/LawCollectionPage';
 import { LawRiskPage } from '@/pages/ui/LawRiskPage';
+import {
+  OAUTH_LOGIN_STARTED_KEY,
+  logout,
+  onboarding,
+  reissue,
+  startGoogleLogin,
+} from '@/api/auth';
+import { getMyInfo, updateUserCountries } from '@/api/user';
+import { INTEREST_COUNTRIES } from '@/constants/interestCountries';
+import env from '@/lib/env';
+import { mapCountryCodesToIds } from '@/lib/countryIds';
+
+type AuthStatus = 'checking' | 'anonymous' | 'guest' | 'user';
+
+const VALID_COUNTRY_CODES = new Set(
+  INTEREST_COUNTRIES.map((country) => country.code),
+);
+const AUTH_SESSION_KEY = 'glaw:has-auth-session';
+
+const shouldCheckAuthOnRoute = (pathname: string): boolean => {
+  if (typeof window === 'undefined') return false;
+  if (pathname === '/login') return false;
+
+  return (
+    window.sessionStorage.getItem(OAUTH_LOGIN_STARTED_KEY) === 'true' ||
+    window.localStorage.getItem(AUTH_SESSION_KEY) === 'true'
+  );
+};
+
+const rememberAuthSession = () => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(AUTH_SESSION_KEY, 'true');
+  window.sessionStorage.removeItem(OAUTH_LOGIN_STARTED_KEY);
+};
+
+const forgetAuthSession = () => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.removeItem(AUTH_SESSION_KEY);
+  window.sessionStorage.removeItem(OAUTH_LOGIN_STARTED_KEY);
+};
+
+const getApiErrorCode = (error: unknown): string | undefined => {
+  if (!error || typeof error !== 'object') return undefined;
+
+  const response = (error as { response?: { data?: { code?: unknown } } })
+    .response;
+  return typeof response?.data?.code === 'string'
+    ? response.data.code
+    : undefined;
+};
+
+const normalizeCountryCodes = (codes: string[]): CountryCode[] =>
+  Array.from(
+    new Set(
+      codes
+        .map((code) => code.toUpperCase())
+        .filter((code): code is CountryCode => VALID_COUNTRY_CODES.has(code)),
+    ),
+  );
 
 export const AppRoutes = () => {
   const navigate = useNavigate();
-  const forceLogin =
-    import.meta.env.DEV && import.meta.env.VITE_FORCE_LOGIN === 'true';
+  const location = useLocation();
   const {
     preferredCountries,
     savePreferredCountries,
     clearPreferredCountries,
-    hasPreferredCountries,
   } = usePreferredCountries();
 
-  const [isLoggedIn, setIsLoggedIn] = useState(
-    () => forceLogin || hasPreferredCountries,
-  );
-  const [isInterestModalOpen, setIsInterestModalOpen] = useState(false);
-  // 모달에서만 사용하는 임시 선택값
-  // 저장 시 usePreferredCountries에 반영
+  const [authStatus, setAuthStatus] = useState<AuthStatus>('checking');
   const [modalSelection, setModalSelection] = useState(preferredCountries);
+  const [isOnboardingSaving, setIsOnboardingSaving] = useState(false);
+
+  const applyMyInfo = useCallback(
+    (me: Awaited<ReturnType<typeof getMyInfo>>) => {
+      const codes = normalizeCountryCodes(
+        me.countries.map((country) => country.code),
+      );
+      rememberAuthSession();
+      savePreferredCountries(codes);
+      setModalSelection(codes);
+      setAuthStatus(me.role === 'ROLE_GUEST' ? 'guest' : 'user');
+    },
+    [savePreferredCountries],
+  );
 
   useEffect(() => {
-    if (forceLogin || hasPreferredCountries) {
-      setIsLoggedIn(true);
-      setModalSelection(preferredCountries);
+    if (location.pathname === '/login') {
+      forgetAuthSession();
+      clearPreferredCountries();
+      setModalSelection([]);
+      setAuthStatus('anonymous');
+      return;
     }
-  }, [forceLogin, hasPreferredCountries, preferredCountries]);
+
+    if (
+      location.pathname === '/onboarding' &&
+      typeof window !== 'undefined' &&
+      window.sessionStorage.getItem(OAUTH_LOGIN_STARTED_KEY) === 'true'
+    ) {
+      setAuthStatus('guest');
+      return;
+    }
+
+    if (!shouldCheckAuthOnRoute(location.pathname)) {
+      clearPreferredCountries();
+      setModalSelection([]);
+      setAuthStatus('anonymous');
+      return;
+    }
+
+    let isMounted = true;
+
+    void (async () => {
+      try {
+        const me = await getMyInfo();
+        if (!isMounted) return;
+        applyMyInfo(me);
+      } catch {
+        try {
+          await reissue();
+          const me = await getMyInfo();
+          if (!isMounted) return;
+          applyMyInfo(me);
+        } catch {
+          if (!isMounted) return;
+          forgetAuthSession();
+          clearPreferredCountries();
+          setModalSelection([]);
+          setAuthStatus('anonymous');
+        }
+      }
+    })();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [applyMyInfo, clearPreferredCountries, location.pathname]);
 
   const handleSkipInterest = () => {
-    setIsInterestModalOpen(false);
+    window.alert('온보딩 완료 후 서비스를 이용할 수 있습니다.');
   };
 
-  const LoginRoute = () => {
-    const handleGoogleLogin = () => {
-      console.log('Google 로그인 버튼 클릭!');
-    };
+  const handleGoogleLogin = () => {
+    startGoogleLogin();
+  };
 
-    const handleSaveInterest = (countries: CountryCode[]) => {
-      savePreferredCountries(countries);
-      setIsInterestModalOpen(false);
-    };
+  const handleSaveInterest = (countries: CountryCode[]) => {
+    void (async () => {
+      const { countryIds, missingCodes } = mapCountryCodesToIds(
+        countries,
+        env.countryIdMap,
+      );
 
-    const handleLogout = () => {
-      clearPreferredCountries();
-      if (typeof window !== 'undefined') {
-        window.localStorage.removeItem('savedLaws');
+      if (missingCodes.length > 0) {
+        window.alert(
+          `countryId 매핑이 없는 국가가 있습니다: ${missingCodes.join(', ')}`,
+        );
+        return;
       }
-      setIsLoggedIn(false);
-      void navigate('/login');
-    };
 
-    return (
-      <>
-        <Routes>
-          <Route
-            path="/"
-            element={
-              isLoggedIn ? (
-                <MainDashboardPage preferredCountries={preferredCountries} />
-              ) : (
-                <Navigate to="/login" replace />
-              )
-            }
-          />
-          <Route
-            path="/login"
-            element={
-              isLoggedIn ? (
-                <Navigate to="/" replace />
-              ) : (
-                <LoginPage onGoogleLogin={handleGoogleLogin} />
-              )
-            }
-          />
-          <Route
-            path="/law-collection"
-            element={
-              isLoggedIn ? (
-                <LawCollectionPage />
-              ) : (
-                <Navigate to="/login" replace />
-              )
-            }
-          />
-          <Route
-            path="/ai-consulting"
-            element={
-              isLoggedIn ? <AiChatPage /> : <Navigate to="/login" replace />
-            }
-          />
-          <Route
-            path="/law-compare"
-            element={
-              isLoggedIn ? (
-                <LawComparisonPage />
-              ) : (
-                <Navigate to="/login" replace />
-              )
-            }
-          />
-          <Route
-            path="/law-risk"
-            element={
-              isLoggedIn ? <LawRiskPage /> : <Navigate to="/login" replace />
-            }
-          />
-          <Route
-            path="/mypage"
-            element={
-              isLoggedIn ? (
-                <MyPage
-                  preferredCountries={preferredCountries}
-                  onSavePreferredCountries={savePreferredCountries}
-                  onLogout={handleLogout}
-                />
-              ) : (
-                <Navigate to="/login" replace />
-              )
-            }
-          />
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
+      setIsOnboardingSaving(true);
+      try {
+        await onboarding({ countryIds });
+        const me = await getMyInfo();
+        applyMyInfo(me);
 
-        <InterestCountryModal
-          open={isInterestModalOpen}
-          initialSelected={modalSelection}
-          onSkip={handleSkipInterest}
-          onSave={handleSaveInterest}
-        />
-      </>
-    );
+        if (me.role === 'ROLE_USER') {
+          void navigate('/');
+        }
+      } catch (error) {
+        if (getApiErrorCode(error) === 'ONBOARDING_ALREADY_COMPLETED') {
+          try {
+            const me = await getMyInfo();
+            applyMyInfo(me);
+            void navigate('/');
+            return;
+          } catch {
+            // Fall through to the generic error message.
+          }
+        }
+        window.alert('온보딩 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      } finally {
+        setIsOnboardingSaving(false);
+      }
+    })();
   };
 
-  return <LoginRoute />;
+  const handleSavePreferredCountries = async (countries: CountryCode[]) => {
+    const { countryIds, missingCodes } = mapCountryCodesToIds(
+      countries,
+      env.countryIdMap,
+    );
+
+    if (missingCodes.length > 0) {
+      window.alert(
+        `countryId 매핑이 없는 국가가 있습니다: ${missingCodes.join(', ')}`,
+      );
+      throw new Error('Missing countryId mapping');
+    }
+
+    try {
+      await updateUserCountries({ countryIds });
+      const me = await getMyInfo();
+      applyMyInfo(me);
+    } catch {
+      window.alert('관심 국가 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+      throw new Error('Failed to update user countries');
+    }
+  };
+
+  const handleLogout = () => {
+    void (async () => {
+      try {
+        await logout();
+      } finally {
+        clearPreferredCountries();
+        forgetAuthSession();
+        if (typeof window !== 'undefined') {
+          window.localStorage.removeItem('savedLaws');
+        }
+        setAuthStatus('anonymous');
+        void navigate('/login');
+      }
+    })();
+  };
+
+  if (authStatus === 'checking') {
+    return (
+      <div className="flex min-h-screen items-center justify-center text-text-secondary">
+        로그인 상태 확인 중...
+      </div>
+    );
+  }
+
+  return (
+    <Routes>
+      <Route
+        path="/"
+        element={
+          authStatus === 'user' ? (
+            <MainDashboardPage preferredCountries={preferredCountries} />
+          ) : (
+            <Navigate
+              to={authStatus === 'guest' ? '/onboarding' : '/login'}
+              replace
+            />
+          )
+        }
+      />
+      <Route
+        path="/login"
+        element={
+          authStatus === 'anonymous' ? (
+            <LoginPage onGoogleLogin={handleGoogleLogin} />
+          ) : (
+            <Navigate
+              to={authStatus === 'guest' ? '/onboarding' : '/'}
+              replace
+            />
+          )
+        }
+      />
+      <Route
+        path="/onboarding"
+        element={
+          authStatus === 'guest' ? (
+            <div className="min-h-screen bg-bg-soft">
+              <InterestCountryModal
+                open
+                initialSelected={modalSelection}
+                onSkip={handleSkipInterest}
+                onSave={handleSaveInterest}
+              />
+              {isOnboardingSaving ? (
+                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/20 text-white">
+                  저장 중...
+                </div>
+              ) : null}
+            </div>
+          ) : (
+            <Navigate to={authStatus === 'user' ? '/' : '/login'} replace />
+          )
+        }
+      />
+      <Route
+        path="/law-collection"
+        element={
+          authStatus === 'user' ? (
+            <LawCollectionPage />
+          ) : (
+            <Navigate to="/login" replace />
+          )
+        }
+      />
+      <Route
+        path="/ai-consulting"
+        element={
+          authStatus === 'user' ? (
+            <AiChatPage />
+          ) : (
+            <Navigate to="/login" replace />
+          )
+        }
+      />
+      <Route
+        path="/law-compare"
+        element={
+          authStatus === 'user' ? (
+            <LawComparisonPage />
+          ) : (
+            <Navigate to="/login" replace />
+          )
+        }
+      />
+      <Route
+        path="/law-risk"
+        element={
+          authStatus === 'user' ? (
+            <LawRiskPage />
+          ) : (
+            <Navigate to="/login" replace />
+          )
+        }
+      />
+      <Route
+        path="/mypage"
+        element={
+          authStatus === 'user' ? (
+            <MyPage
+              preferredCountries={preferredCountries}
+              onSavePreferredCountries={handleSavePreferredCountries}
+              onLogout={handleLogout}
+            />
+          ) : (
+            <Navigate to="/login" replace />
+          )
+        }
+      />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  );
 };
 
 export default AppRoutes;

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -22,6 +22,15 @@ export const AppRoutes = () => {
     handleLogout,
   } = useAuthFlow();
 
+  const protectedRedirectPath =
+    authStatus === 'guest' ? '/onboarding' : '/login';
+
+  const myPageProps = {
+    preferredCountries,
+    onSavePreferredCountries: handleSavePreferredCountries,
+    onLogout: handleLogout,
+  };
+
   if (authStatus === 'checking') {
     return (
       <div className="flex min-h-screen items-center justify-center text-text-secondary">
@@ -86,7 +95,7 @@ export const AppRoutes = () => {
           authStatus === 'user' ? (
             <LawCollectionPage />
           ) : (
-            <Navigate to="/login" replace />
+            <Navigate to={protectedRedirectPath} replace />
           )
         }
       />
@@ -96,7 +105,7 @@ export const AppRoutes = () => {
           authStatus === 'user' ? (
             <AiChatPage />
           ) : (
-            <Navigate to="/login" replace />
+            <Navigate to={protectedRedirectPath} replace />
           )
         }
       />
@@ -106,7 +115,7 @@ export const AppRoutes = () => {
           authStatus === 'user' ? (
             <LawComparisonPage />
           ) : (
-            <Navigate to="/login" replace />
+            <Navigate to={protectedRedirectPath} replace />
           )
         }
       />
@@ -116,7 +125,7 @@ export const AppRoutes = () => {
           authStatus === 'user' ? (
             <LawRiskPage />
           ) : (
-            <Navigate to="/login" replace />
+            <Navigate to={protectedRedirectPath} replace />
           )
         }
       />
@@ -124,13 +133,9 @@ export const AppRoutes = () => {
         path="/mypage"
         element={
           authStatus === 'user' ? (
-            <MyPage
-              preferredCountries={preferredCountries}
-              onSavePreferredCountries={handleSavePreferredCountries}
-              onLogout={handleLogout}
-            />
+            <MyPage {...myPageProps} />
           ) : (
-            <Navigate to="/login" replace />
+            <Navigate to={protectedRedirectPath} replace />
           )
         }
       />

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -1,238 +1,26 @@
-import { useCallback, useEffect, useState } from 'react';
-import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import { LoginPage } from '@/pages/ui/LoginPage';
 import { InterestCountryModal } from '@/components/interest/InterestCountryModal';
-import { usePreferredCountries } from '@/hooks/usePreferredCountries';
-import type { CountryCode } from '@/types/country';
 import { MyPage } from '@/pages/ui/MyPage';
 import { AiChatPage } from '@/pages/ui/AiChatPage';
 import { LawComparisonPage } from '@/pages/ui/LawComparisonPage';
 import { MainDashboardPage } from '@/pages/ui/MainDashboardPage';
 import { LawCollectionPage } from '@/pages/ui/LawCollectionPage';
 import { LawRiskPage } from '@/pages/ui/LawRiskPage';
-import {
-  OAUTH_LOGIN_STARTED_KEY,
-  logout,
-  onboarding,
-  reissue,
-  startGoogleLogin,
-} from '@/api/auth';
-import { getMyInfo, updateUserCountries } from '@/api/user';
-import { INTEREST_COUNTRIES } from '@/constants/interestCountries';
-import env from '@/lib/env';
-import { mapCountryCodesToIds } from '@/lib/countryIds';
-
-type AuthStatus = 'checking' | 'anonymous' | 'guest' | 'user';
-
-const VALID_COUNTRY_CODES = new Set(INTEREST_COUNTRIES.map((country) => country.code));
-const AUTH_SESSION_KEY = 'glaw:has-auth-session';
-
-const shouldCheckAuthOnRoute = (pathname: string): boolean => {
-  if (typeof window === 'undefined') return false;
-  if (pathname === '/login') return false;
-
-  return (
-    window.sessionStorage.getItem(OAUTH_LOGIN_STARTED_KEY) === 'true' ||
-    window.localStorage.getItem(AUTH_SESSION_KEY) === 'true'
-  );
-};
-
-const rememberAuthSession = () => {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem(AUTH_SESSION_KEY, 'true');
-  window.sessionStorage.removeItem(OAUTH_LOGIN_STARTED_KEY);
-};
-
-const forgetAuthSession = () => {
-  if (typeof window === 'undefined') return;
-  window.localStorage.removeItem(AUTH_SESSION_KEY);
-  window.sessionStorage.removeItem(OAUTH_LOGIN_STARTED_KEY);
-};
-
-const getApiErrorCode = (error: unknown): string | undefined => {
-  if (!error || typeof error !== 'object') return undefined;
-
-  const response = (error as { response?: { data?: { code?: unknown } } }).response;
-  return typeof response?.data?.code === 'string'
-    ? response.data.code
-    : undefined;
-};
-
-const normalizeCountryCodes = (codes: string[]): CountryCode[] =>
-  Array.from(
-    new Set(
-      codes
-        .map((code) => code.toUpperCase())
-        .filter((code): code is CountryCode => VALID_COUNTRY_CODES.has(code)),
-    ),
-  );
+import { useAuthFlow } from '@/hooks/useAuthFlow';
 
 export const AppRoutes = () => {
-  const navigate = useNavigate();
-  const location = useLocation();
   const {
+    authStatus,
     preferredCountries,
-    savePreferredCountries,
-    clearPreferredCountries,
-  } = usePreferredCountries();
-
-  const [authStatus, setAuthStatus] = useState<AuthStatus>('checking');
-  const [modalSelection, setModalSelection] = useState(preferredCountries);
-  const [isOnboardingSaving, setIsOnboardingSaving] = useState(false);
-
-  const applyMyInfo = useCallback(
-    (me: Awaited<ReturnType<typeof getMyInfo>>) => {
-      const codes = normalizeCountryCodes(
-        me.countries.map((country) => country.code),
-      );
-      rememberAuthSession();
-      savePreferredCountries(codes);
-      setModalSelection(codes);
-      setAuthStatus(me.role === 'ROLE_GUEST' ? 'guest' : 'user');
-    },
-    [savePreferredCountries],
-  );
-
-  useEffect(() => {
-    if (location.pathname === '/login') {
-      forgetAuthSession();
-      clearPreferredCountries();
-      setModalSelection([]);
-      setAuthStatus('anonymous');
-      return;
-    }
-
-    if (
-      location.pathname === '/onboarding' &&
-      typeof window !== 'undefined' &&
-      window.sessionStorage.getItem(OAUTH_LOGIN_STARTED_KEY) === 'true'
-    ) {
-      setAuthStatus('guest');
-      return;
-    }
-
-    if (!shouldCheckAuthOnRoute(location.pathname)) {
-      clearPreferredCountries();
-      setModalSelection([]);
-      setAuthStatus('anonymous');
-      return;
-    }
-
-    let isMounted = true;
-
-    void (async () => {
-      try {
-        const me = await getMyInfo();
-        if (!isMounted) return;
-        applyMyInfo(me);
-      } catch {
-        try {
-          await reissue();
-          const me = await getMyInfo();
-          if (!isMounted) return;
-          applyMyInfo(me);
-        } catch {
-          if (!isMounted) return;
-          forgetAuthSession();
-          clearPreferredCountries();
-          setModalSelection([]);
-          setAuthStatus('anonymous');
-        }
-      }
-    })();
-
-    return () => {
-      isMounted = false;
-    };
-  }, [applyMyInfo, clearPreferredCountries, location.pathname]);
-
-  const handleSkipInterest = () => {
-    window.alert('온보딩 완료 후 서비스를 이용할 수 있습니다.');
-  };
-
-  const handleGoogleLogin = () => {
-    startGoogleLogin();
-  };
-
-  const handleSaveInterest = (countries: CountryCode[]) => {
-    void (async () => {
-      const { countryIds, missingCodes } = mapCountryCodesToIds(
-        countries,
-        env.countryIdMap,
-      );
-
-      if (missingCodes.length > 0) {
-        window.alert(
-          `countryId 매핑이 없는 국가가 있습니다: ${missingCodes.join(', ')}`,
-        );
-        return;
-      }
-
-      setIsOnboardingSaving(true);
-      try {
-        await onboarding({ countryIds });
-        const me = await getMyInfo();
-        applyMyInfo(me);
-
-        if (me.role === 'ROLE_USER') {
-          void navigate('/');
-        }
-      } catch (error) {
-        if (getApiErrorCode(error) === 'ONBOARDING_ALREADY_COMPLETED') {
-          try {
-            const me = await getMyInfo();
-            applyMyInfo(me);
-            void navigate('/');
-            return;
-          } catch {
-            // Fall through to the generic error message.
-          }
-        }
-        window.alert('온보딩 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.');
-      } finally {
-        setIsOnboardingSaving(false);
-      }
-    })();
-  };
-
-  const handleSavePreferredCountries = async (countries: CountryCode[]) => {
-    const { countryIds, missingCodes } = mapCountryCodesToIds(
-      countries,
-      env.countryIdMap,
-    );
-
-    if (missingCodes.length > 0) {
-      window.alert(
-        `countryId 매핑이 없는 국가가 있습니다: ${missingCodes.join(', ')}`,
-      );
-      throw new Error('Missing countryId mapping');
-    }
-
-    try {
-      await updateUserCountries({ countryIds });
-      const me = await getMyInfo();
-      applyMyInfo(me);
-    } catch {
-      window.alert('관심 국가 저장에 실패했습니다. 잠시 후 다시 시도해 주세요.');
-      throw new Error('Failed to update user countries');
-    }
-  };
-
-  const handleLogout = () => {
-    void (async () => {
-      try {
-        await logout();
-      } finally {
-        clearPreferredCountries();
-        forgetAuthSession();
-        if (typeof window !== 'undefined') {
-          window.localStorage.removeItem('savedLaws');
-        }
-        setAuthStatus('anonymous');
-        void navigate('/login');
-      }
-    })();
-  };
+    modalSelection,
+    isOnboardingSaving,
+    handleGoogleLogin,
+    handleSkipInterest,
+    handleSaveInterest,
+    handleSavePreferredCountries,
+    handleLogout,
+  } = useAuthFlow();
 
   if (authStatus === 'checking') {
     return (
@@ -250,7 +38,10 @@ export const AppRoutes = () => {
           authStatus === 'user' ? (
             <MainDashboardPage preferredCountries={preferredCountries} />
           ) : (
-            <Navigate to={authStatus === 'guest' ? '/onboarding' : '/login'} replace />
+            <Navigate
+              to={authStatus === 'guest' ? '/onboarding' : '/login'}
+              replace
+            />
           )
         }
       />
@@ -260,7 +51,10 @@ export const AppRoutes = () => {
           authStatus === 'anonymous' ? (
             <LoginPage onGoogleLogin={handleGoogleLogin} />
           ) : (
-            <Navigate to={authStatus === 'guest' ? '/onboarding' : '/'} replace />
+            <Navigate
+              to={authStatus === 'guest' ? '/onboarding' : '/'}
+              replace
+            />
           )
         }
       />
@@ -289,13 +83,21 @@ export const AppRoutes = () => {
       <Route
         path="/law-collection"
         element={
-          authStatus === 'user' ? <LawCollectionPage /> : <Navigate to="/login" replace />
+          authStatus === 'user' ? (
+            <LawCollectionPage />
+          ) : (
+            <Navigate to="/login" replace />
+          )
         }
       />
       <Route
         path="/ai-consulting"
         element={
-          authStatus === 'user' ? <AiChatPage /> : <Navigate to="/login" replace />
+          authStatus === 'user' ? (
+            <AiChatPage />
+          ) : (
+            <Navigate to="/login" replace />
+          )
         }
       />
       <Route

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -1,11 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import {
-  Navigate,
-  Route,
-  Routes,
-  useLocation,
-  useNavigate,
-} from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { LoginPage } from '@/pages/ui/LoginPage';
 import { InterestCountryModal } from '@/components/interest/InterestCountryModal';
 import { usePreferredCountries } from '@/hooks/usePreferredCountries';
@@ -30,9 +24,7 @@ import { mapCountryCodesToIds } from '@/lib/countryIds';
 
 type AuthStatus = 'checking' | 'anonymous' | 'guest' | 'user';
 
-const VALID_COUNTRY_CODES = new Set(
-  INTEREST_COUNTRIES.map((country) => country.code),
-);
+const VALID_COUNTRY_CODES = new Set(INTEREST_COUNTRIES.map((country) => country.code));
 const AUTH_SESSION_KEY = 'glaw:has-auth-session';
 
 const shouldCheckAuthOnRoute = (pathname: string): boolean => {
@@ -60,8 +52,7 @@ const forgetAuthSession = () => {
 const getApiErrorCode = (error: unknown): string | undefined => {
   if (!error || typeof error !== 'object') return undefined;
 
-  const response = (error as { response?: { data?: { code?: unknown } } })
-    .response;
+  const response = (error as { response?: { data?: { code?: unknown } } }).response;
   return typeof response?.data?.code === 'string'
     ? response.data.code
     : undefined;
@@ -259,10 +250,7 @@ export const AppRoutes = () => {
           authStatus === 'user' ? (
             <MainDashboardPage preferredCountries={preferredCountries} />
           ) : (
-            <Navigate
-              to={authStatus === 'guest' ? '/onboarding' : '/login'}
-              replace
-            />
+            <Navigate to={authStatus === 'guest' ? '/onboarding' : '/login'} replace />
           )
         }
       />
@@ -272,10 +260,7 @@ export const AppRoutes = () => {
           authStatus === 'anonymous' ? (
             <LoginPage onGoogleLogin={handleGoogleLogin} />
           ) : (
-            <Navigate
-              to={authStatus === 'guest' ? '/onboarding' : '/'}
-              replace
-            />
+            <Navigate to={authStatus === 'guest' ? '/onboarding' : '/'} replace />
           )
         }
       />
@@ -304,21 +289,13 @@ export const AppRoutes = () => {
       <Route
         path="/law-collection"
         element={
-          authStatus === 'user' ? (
-            <LawCollectionPage />
-          ) : (
-            <Navigate to="/login" replace />
-          )
+          authStatus === 'user' ? <LawCollectionPage /> : <Navigate to="/login" replace />
         }
       />
       <Route
         path="/ai-consulting"
         element={
-          authStatus === 'user' ? (
-            <AiChatPage />
-          ) : (
-            <Navigate to="/login" replace />
-          )
+          authStatus === 'user' ? <AiChatPage /> : <Navigate to="/login" replace />
         }
       />
       <Route

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  // Optional because src/lib/env.ts provides runtime defaults for local/preview environments.
   readonly VITE_API_BASE_URL?: string;
   readonly VITE_AI_API_BASE_URL?: string;
   readonly VITE_GOOGLE_LOGIN_URL?: string;


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #38 //이슈 번호는 추적을 위해 필요합니다!
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 구글 OAuth 기반 로그인 흐름 연결, 쿠키 기반 인증 상태 확인/재발급/로그아웃/온보딩 API 연동
- 온보딩 및 마이페이지 관심 국가 저장 시 백엔드 API로 `countryIds`를 전달하도록 수정
- 전달받은 country_id 매핑 기준 반영
- 인증/온보딩/로그아웃 관련 로직은 `useAuthFlow` 훅으로 분리


<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 빌드 / 타입 에러 확인을 진행하였습니다.

📣 **To Reviewers**
---
<!-- 전달사항 -->

- 구글 로그인은 `VITE_GOOGLE_LOGIN_URL`로 이동해 백엔드 OAuth 흐름을 시작합니다.
- API 요청은 쿠키 기반 인증을 위해 `withCredentials: true`로 동작합니다.
- 국가 ID 매핑은 현재 국가 단위 기본값 기준입니다.
  - US: 1
  - CA: 4
  - AU: 7
- 주(state) 선택 UI는 아직 없어서 `US-CA: 2`, `US-NY: 3` 같은 주 단위 ID는 추후 확장 대상입니다.

- Reviewers : 팀원
- Assignees: 자기 자신
- Labels : 작업 유형, 자기 자신

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Google 로그인 흐름 도입 및 인증/온보딩 레이어 추가
  * 사용자 정보 조회 및 관심 국가 저장 기능 추가

* **개선 사항**
  * 온보딩·관심사 저장의 비동기 처리 및 저장 중 UI(비활성화·"저장 중..." 표시) 개선
  * 라우팅이 인증 상태 기반으로 전환되어 접근 제어 강화
  * 관심 국가 목록 순서 조정 및 환경 기반 설정/매핑 도입
<!-- end of auto-generated comment: release notes by coderabbit.ai -->