### PR TITLE
[feat] User API 연동

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 VITE_API_BASE_URL=https://api.glaw.site/ai
 VITE_LAW_COMPARE_PATH=/api/v1/ai/compare
 VITE_LEGAL_RISK_PATH=/api/risk
+VITE_COUNTRY_ID_MAP={"US":1,"CA":4,"AU":7}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,18 @@
+import { useEffect } from 'react';
 import AppRoutes from '@/routes/routes';
+import { getHealth } from '@/api/health';
 
 const App = () => {
+  useEffect(() => {
+    void (async () => {
+      try {
+        await getHealth();
+      } catch (error) {
+        console.warn('Health check failed', error);
+      }
+    })();
+  }, []);
+
   return <AppRoutes />;
 };
 

--- a/src/api/health.ts
+++ b/src/api/health.ts
@@ -1,0 +1,8 @@
+import apiClient from '@/lib/apiClient';
+
+export const getHealth = async (): Promise<string> => {
+  const { data } = await apiClient.get<string>('/health', {
+    responseType: 'text',
+  });
+  return data;
+};

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -6,8 +6,8 @@ export type UserCountry = {
   countryId: number;
   code: string;
   name: string;
-  stateCode?: string;
-  stateName?: string;
+  stateCode: string | null;
+  stateName: string | null;
 };
 
 export type UserMe = {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -6,16 +6,12 @@ const getDefaultApiBaseUrl = (): string => {
   return window.location.origin;
 };
 
-const DEFAULT_COUNTRY_ID_MAP: Record<string, number> = {
-  US: 1,
-  CA: 4,
-  AU: 7,
-};
-
 const parseCountryIdMap = (
   value: string | undefined,
 ): Record<string, number> => {
-  if (!value) return DEFAULT_COUNTRY_ID_MAP;
+  if (!value) {
+    throw new Error('Missing required environment variable: VITE_COUNTRY_ID_MAP');
+  }
 
   try {
     const parsed = JSON.parse(value) as Record<string, unknown>;

--- a/src/pages/ui/MyPage.tsx
+++ b/src/pages/ui/MyPage.tsx
@@ -15,7 +15,6 @@ import {
 } from '@/components/common/DashboardTabs';
 import { Button } from '@/components/common/button/Button';
 import { LawDetailModal } from '@/components/law/LawDetailModal';
-import { mockCompareSets } from '@/mocks/mypage';
 import type { PreferredCountries } from '@/types/country';
 import type { CompareSet } from '@/types/mypage';
 import type { LawItem } from '@/types/law';
@@ -41,7 +40,7 @@ export const MyPage = ({
   const [isSavingInterests, setIsSavingInterests] = useState(false);
   const [interestSelection, setInterestSelection] =
     useState<PreferredCountries>(preferredCountries);
-  const [compareSets, setCompareSets] = useState<CompareSet[]>(mockCompareSets);
+  const [compareSets, setCompareSets] = useState<CompareSet[]>([]);
   const [selectedLaw, setSelectedLaw] = useState<LawItem | null>(null);
   const { savedIds, toggleSaved } = useSavedLaws();
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,12 +1,12 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  // Optional because src/lib/env.ts provides runtime defaults for local/preview environments.
+  // Optional values use runtime defaults in src/lib/env.ts.
   readonly VITE_API_BASE_URL?: string;
   readonly VITE_AI_API_BASE_URL?: string;
   readonly VITE_GOOGLE_LOGIN_URL?: string;
   readonly VITE_LOGIN_REDIRECT_URL?: string;
-  readonly VITE_COUNTRY_ID_MAP?: string;
+  readonly VITE_COUNTRY_ID_MAP: string;
   readonly VITE_FORCE_LOGIN?: string;
 }
 


### PR DESCRIPTION
## 개요
- closed #47

- User API 연동으로 내 정보 조회 및 관심 국가 수정 흐름을 연결
- 앱 시작 시 서버 상태 확인을 위해 Health API를 호출하도록 추가
- `/api/users/me` 응답의 `stateCode`, `stateName` null 케이스를 타입에 반영
- 마이페이지 비교 조합 탭에서 mock 데이터가 강제로 노출되지 않도록 제거
- 마이페이지 props 전달 시 비동기 핸들러 관련 lint 경고를 수정

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 빌드 / 타입 에러 확인을 진행하였습니다.

📣 **To Reviewers**
---
- `GET /api/users/me`는 로그인된 사용자의 정보와 관심 국가 목록을 조회합니다.
- `PATCH /api/users/countries`는 마이페이지 관심 국가 수정 시 `countryIds` 배열을 전달합니다.
- `GET /health`는 앱 시작 시 서버 상태 확인용으로 호출합니다.
- Health API 응답은 JSON이 아닌 문자열 `ok` 형태라 `responseType: 'text'`로 처리했습니다.
- 현재 비교 조합 저장/조회 API가 없어 마이페이지 비교 조합 mock 데이터는 제거했습니다.
- Swagger 기준 `PATCH /api/users/countries`에서 500 에러가 발생했던 이력이 있어 백엔드 동작 확인이 필요합니다.

- Reviewers : 팀원
- Assignees: 자기 자신
- Labels : feature, 자기 자신

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 애플리케이션 시작 시 헬스 체크 기능 추가

* **설정 변경**
  * 국가 ID 매핑 환경 변수가 필수로 지정되었습니다. `.env.example`에서 설정이 필요합니다.

* **개선사항**
  * 데이터 검증 로직을 강화하여 필수 환경 변수 누락 시 명확한 오류 메시지 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->